### PR TITLE
Testing for 0.3

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -92,7 +92,7 @@ The behaviors of the console are tested in [Console section](#consoles).
 ##### Validations
 
 - [ ] show error on invalid json
-- [ ] show error when top-level keys has keys other than `keymaps`, and `search`
+- [ ] show error when top-level keys has keys other than `keymaps`, `search`, and `blacklist`
 
 ##### `"keymaps"` section
 

--- a/QA.md
+++ b/QA.md
@@ -125,3 +125,24 @@ The behaviors of the console are tested in [Console section](#consoles).
 #### Empty suggestion (#65)
 
 - [ ] Show competions for `:open`/`:tabopen`/`:buffer` on console after closed
+
+#### Disable add-on temporary (#86)
+
+- [ ] Toggle enabled/disabled of plugin bu <kbd>Shift</kbd>+<kbd>Esc</kbd>
+
+#### URL blacklist (#90)
+
+- [ ] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
+- [ ] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
+- [ ] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
+- [ ] `github.com` blocks both `github.com/` and `github.com/a`
+- [ ] `*.github.com` blocks `gist.github.com/`, and not `github.com`
+
+#### Improve for aberration pages (#93)
+
+- [ ] able to scroll on Gmail and Slack
+
+#### Link with target='_blank' link (#94)
+
+- [ ] open link with target='_blank' in new tab by <kbd>f</kbd>
+- [ ] open link with target='_blank' in new tab by <kbd>F</kbd>

--- a/src/content/scrolls.js
+++ b/src/content/scrolls.js
@@ -75,9 +75,9 @@ const scrollHorizonally = (win, count) => {
 
 const scrollPages = (win, count) => {
   let target = scrollTarget(win);
-  let height = target.innerHeight;
+  let height = target.clientHeight;
   let x = target.scrollLeft;
-  let y = target.scrollLeft + height * count;
+  let y = target.scrollTop + height * count;
   target.scrollTo(x, y);
 };
 


### PR DESCRIPTION
### Checklist for testing Vim Vixen

#### Operations

Test operations with default key maps.

##### Scrolling

- [x] <kbd>k</kbd> or <kbd>Ctrl</kbd>+<kbd>Y</kbd>, <kbd>j</kbd> or <kbd>Ctrl</kbd>+<kbd>E</kbd>: scroll up and down
- [x] <kbd>h</kbd>, <kbd>l</kbd>: scroll left and right
- [x] <kbd>Ctrl</kbd>+<kbd>U</kbd>, <kbd>Ctrl</kbd>+<kbd>D</kbd>: scroll up and down by half of screen
- [x] <kbd>Ctrl</kbd>+<kbd>B</kbd>, <kbd>Ctrl</kbd>+<kbd>F</kbd>: scroll up and down by a screen
- [x] <kbd>0</kbd>, <kbd>$</kbd>: scroll to leftmost and rightmost
- [x] <kbd>g</kbd><kbd>g</kbd>, <kbd>G</kbd>: scroll to top and bottom

##### Console

The behaviors of the console are tested in [Console section](#consoles).

- [x] <kbd>:</kbd>: open empty console
- [x] <kbd>o</kbd>, <kbd>t</kbd>, <kbd>w</kbd>: open a console with `open`, `tabopen`, `winopen`
- [x] <kbd>O</kbd>, <kbd>T</kbd>, <kbd>W</kbd>: open a console with `open`, `tabopen`, `winopen` and current URL
- [x] <kbd>b</kbd>: open a consolw with `buffer`

##### Tabs

- [x] <kbd>d</kbd>: delete current tab
- [x] <kbd>u</kbd>: reopen close tab
- [x] <kbd>K</kbd>, <kbd>J</kbd>: select prev and next tab
- [x] <kbd>r</kbd>: reload current tab
- [x] <kbd>R</kbd>: reload current tab without cache

##### Navigation

- [x] <kbd>f</kbd>: start following links
- [x] <kbd>F</kbd>: start following links and open in new tab
- [x] <kbd>H</kbd>, <kbd>L</kbd>: go back and forward in histories
- [x] <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: find prev and next links and open it
- [x] <kbd>g</kbd><kbd>u</kbd>: go to parent directory
- [x] <kbd>g</kbd><kbd>U</kbd>: go to root directory

##### Misc

- [x] <kbd>z</kbd><kbd>i</kbd>, <kbd>z</kbd><kbd>o</kbd>: zoom-in and zoom-out
- [x] <kbd>z</kbd><kbd>z</kbd>: set zoom level as default
- [x] <kbd>y</kbd>: yank current URL and show a message

#### Consoles

##### Exec a command

- [x] `<EMPTY>`, `<SP>`: do nothing
<br>

- [x] `open an apple`: search with keywords "an apple" by default search engine (google)
- [x] `open github.com`: open github.com
- [x] `open https://github.com`: open github.com
- [x] `open yahoo an apple`: search with keywords "an apple" by yahoo.com
- [x] `open yahoo`,`open yahoo<SP>`: search with empty keywords; yahoo redirects to top page
- [x] `open`,`open<SP>`: open default search engine
<br>

- [x] `tabopen`: do avobe tests replaced `open` with `tabopen`, and verify the page is opened in new tab
- [x] `winopen`: do avobe tests replaced `open` with `winopen`, and verify the page is opened in new window
<br>

- [x] `buffer`,`buffer<SP>`: do nothing
- [x] `buffer <title>`, `buffer <url>`: select tab which has an title matched with
- [x] `buffer 1`: select leftmost tab
- [x] `buffer 0`, `buffer 99`: shows an error
- [x] select tabs rotationally when more than two tabs are matched

#### Completions

##### History and search engines

- [x] `open`: show no completions
- [x] `open<SP>`: show all engines and some history items
- [x] `open g`: complete search engines starts with `g` and matched with keywords `g`
- [x] `open foo bar`: complete history items matched with keywords `foo` and `bar`
- [x] also `tabopen` and `winopen`
- shortening commands such as `o` are not test in this release

##### Buffer command

- [x] `buffer`: show no completions
- [x] `buffer<SP>`: show all opened tabs in completion
- [x] `buffer x`: show tabs which has title and URL matches with `x`

#### Settings

##### Validations

- [x] show error on invalid json
- [x] show error when top-level keys has keys other than `keymaps`, `search`, and `blacklist`

##### `"keymaps"` section

- [x] show error on unknown operation name in `"keymaps"`

##### `"search"` section

- validations in `"search"` section are not tested in this release

##### Updating

- [x] changes are updated on textarea blure when no errors
- [x] changes are not updated on textarea blure when errors occurs
- [x] keymap settings are applied to open tabs without reload
- [x] search settings are applied to open tabs without reload

#### Events are fired on Slack and Twitter (#54)

- [x] Fucus text box on Twitter or Slack, press <kbd>j</kbd>, then <kbd>j</kbd> is typed in the box
- [x] Focus the text box on Twitter or Slack on following mode

#### Multi frame support (#61)

- [x] Show hints on following on a page containing `<frame>`/`<iframe>`
- [x] Show hints only inside viewport of the frame on following on a page containing `<frame>`/`<iframe>`
- [x] Show hints only inside top window on following on a page containing `<frame>`/`<iframe>`
- [x] Select link and open it in the frame in `<iframe>`/`<frame`> on following by <kbd>f</kbd>
- [x] Select link and open it in new tab in `<iframe>`/`<frame`> on following by <kbd>F</kbd>

#### Empty suggestion (#65)

- [x] Show competions for `:open`/`:tabopen`/`:buffer` on console after closed

#### Disable add-on temporary (#86)

- [x] Toggle enabled/disabled of plugin bu <kbd>Shift</kbd>+<kbd>Esc</kbd>

#### URL blacklist (#90)

- [x] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
- [x] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
- [x] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
- [x] `github.com` blocks both `github.com/` and `github.com/a`
- [x] `*.github.com` blocks `gist.github.com/`, and not `github.com`

#### Improve for aberration pages (#93)

- [x] able to scroll on Gmail and Slack

#### Link with target='_blank' link (#94)

- [x] open link with target='_blank' in new tab by <kbd>f</kbd>
- [x] open link with target='_blank' in new tab by <kbd>F</kbd>