### PR TITLE
add support for following some buttons on mobile.twitter.com

### DIFF
--- a/src/content/components/common/follow.js
+++ b/src/content/components/common/follow.js
@@ -4,7 +4,8 @@ import * as dom from 'shared/utils/dom';
 
 const TARGET_SELECTOR = [
   'a', 'button', 'input', 'textarea', 'area',
-  '[contenteditable=true]', '[contenteditable=""]', '[tabindex]'
+  '[contenteditable=true]', '[contenteditable=""]', '[tabindex]',
+  '[role="button"]'
 ].join(',');
 
 


### PR DESCRIPTION
Now, Vim vixen can follow some buttons on mobile.twitter.com

The buttons are:

  * reply
  * retweet
  * favorite
  * direct message
  * drop down menu

# old 'follow.start'

![screenshot-2017-11-5 twitter twitter https t co ncxiowi9zu](https://user-images.githubusercontent.com/291273/32411059-963cd48e-c214-11e7-988e-7c19ce93edf4.png)

# new 'follow.start'

![screenshot-2017-11-5 twitter twitter https t co ncxi](https://user-images.githubusercontent.com/291273/32411055-845c7ec2-c214-11e7-85a8-a06adcfabe70.png)
