### PR TITLE
QA 0.4

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -1,10 +1,10 @@
-### Checklist for testing Vim Vixen
+## Checklist for testing Vim Vixen
 
-#### Operations
+### Operations
 
 Test operations with default key maps.
 
-##### Scrolling
+#### Scrolling
 
 - [ ] <kbd>k</kbd> or <kbd>Ctrl</kbd>+<kbd>Y</kbd>, <kbd>j</kbd> or <kbd>Ctrl</kbd>+<kbd>E</kbd>: scroll up and down
 - [ ] <kbd>h</kbd>, <kbd>l</kbd>: scroll left and right
@@ -13,7 +13,7 @@ Test operations with default key maps.
 - [ ] <kbd>0</kbd>, <kbd>$</kbd>: scroll to leftmost and rightmost
 - [ ] <kbd>g</kbd><kbd>g</kbd>, <kbd>G</kbd>: scroll to top and bottom
 
-##### Console
+#### Console
 
 The behaviors of the console are tested in [Console section](#consoles).
 
@@ -22,7 +22,7 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] <kbd>O</kbd>, <kbd>T</kbd>, <kbd>W</kbd>: open a console with `open`, `tabopen`, `winopen` and current URL
 - [ ] <kbd>b</kbd>: open a consolw with `buffer`
 
-##### Tabs
+#### Tabs
 
 - [ ] <kbd>d</kbd>: delete current tab
 - [ ] <kbd>u</kbd>: reopen close tab
@@ -30,21 +30,21 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] <kbd>r</kbd>: reload current tab
 - [ ] <kbd>R</kbd>: reload current tab without cache
 
-##### Navigation
+#### Navigation
 
 - [ ] <kbd>H</kbd>, <kbd>L</kbd>: go back and forward in histories
 - [ ] <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: find prev and next links and open it
 - [ ] <kbd>g</kbd><kbd>u</kbd>: go to parent directory
 - [ ] <kbd>g</kbd><kbd>U</kbd>: go to root directory
 
-##### Misc
+#### Misc
 
 - [ ] <kbd>z</kbd><kbd>i</kbd>, <kbd>z</kbd><kbd>o</kbd>: zoom-in and zoom-out
 - [ ] <kbd>z</kbd><kbd>z</kbd>: set zoom level as default
 - [ ] <kbd>y</kbd>: yank current URL and show a message
 - [ ] Toggle enabled/disabled of plugin bu <kbd>Shift</kbd>+<kbd>Esc</kbd>
 
-#### Following links
+### Following links
 
 - [ ] <kbd>f</kbd>: start following links
 - [ ] <kbd>F</kbd>: start following links and open in new tab
@@ -55,10 +55,11 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] Show hints only inside top window on following on a page containing `<frame>`/`<iframe>`
 - [ ] Select link and open it in the frame in `<iframe>`/`<frame`> on following by <kbd>f</kbd>
 - [ ] Select link and open it in new tab in `<iframe>`/`<frame`> on following by <kbd>F</kbd>
+- [ ] Select link and open it in `<area>` tags, for <kbd>f</kbd> and <kbd>F</kbd>
 
-#### Consoles
+### Consoles
 
-##### Exec a command
+#### Exec a command
 
 - [ ] `<EMPTY>`, `<SP>`: do nothing
 <br>
@@ -81,10 +82,9 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] `buffer 0`, `buffer 99`: shows an error
 - [ ] select tabs rotationally when more than two tabs are matched
 
-#### Completions
+### Completions
 
-
-##### History and search engines
+#### History and search engines
 
 - [ ] `open`: show no completions
 - [ ] `open<SP>`: show all engines and some history items
@@ -94,28 +94,32 @@ The behaviors of the console are tested in [Console section](#consoles).
 - shortening commands such as `o` are not test in this release
 - [ ] Show competions for `:open`/`:tabopen`/`:buffer` on opning just after closed
 
-##### Buffer command
+#### Buffer command
 
 - [ ] `buffer`: show no completions
 - [ ] `buffer<SP>`: show all opened tabs in completion
 - [ ] `buffer x`: show tabs which has title and URL matches with `x`
 
-#### Settings
+#### Misc
 
-##### Validations
+- [ ] Select next item by <kbd>Tab</kbd> and previous item by <kbd>Shift</kbd>+<kbd>Tab</kbd>
+
+### Settings
+
+#### Validations
 
 - [ ] show error on invalid json
 - [ ] show error when top-level keys has keys other than `keymaps`, `search`, and `blacklist`
 
-###### `"keymaps"` section
+##### `"keymaps"` section
 
 - [ ] show error on unknown operation name in `"keymaps"`
 
-###### `"search"` section
+##### `"search"` section
 
 - validations in `"search"` section are not tested in this release
 
-##### `"blacklist"` section
+#### `"blacklist"` section
 
 - [ ] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
 - [ ] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
@@ -123,15 +127,20 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] `github.com` blocks both `github.com/` and `github.com/a`
 - [ ] `*.github.com` blocks `gist.github.com/`, and not `github.com`
 
-##### Updating
+#### Updating
 
 - [ ] changes are updated on textarea blure when no errors
 - [ ] changes are not updated on textarea blure when errors occurs
 - [ ] keymap settings are applied to open tabs without reload
 - [ ] search settings are applied to open tabs without reload
 
-#### For certain sites
+### For certain sites
 
+- [ ] scoll on Hacker News
 - [ ] able to scroll on Gmail and Slack
 - [ ] Fucus text box on Twitter or Slack, press <kbd>j</kbd>, then <kbd>j</kbd> is typed in the box
 - [ ] Focus the text box on Twitter or Slack on following mode
+
+## Misc
+
+- [ ] Work after plugin reload

--- a/QA.md
+++ b/QA.md
@@ -32,8 +32,6 @@ The behaviors of the console are tested in [Console section](#consoles).
 
 ##### Navigation
 
-- [ ] <kbd>f</kbd>: start following links
-- [ ] <kbd>F</kbd>: start following links and open in new tab
 - [ ] <kbd>H</kbd>, <kbd>L</kbd>: go back and forward in histories
 - [ ] <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: find prev and next links and open it
 - [ ] <kbd>g</kbd><kbd>u</kbd>: go to parent directory
@@ -44,6 +42,19 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] <kbd>z</kbd><kbd>i</kbd>, <kbd>z</kbd><kbd>o</kbd>: zoom-in and zoom-out
 - [ ] <kbd>z</kbd><kbd>z</kbd>: set zoom level as default
 - [ ] <kbd>y</kbd>: yank current URL and show a message
+- [ ] Toggle enabled/disabled of plugin bu <kbd>Shift</kbd>+<kbd>Esc</kbd>
+
+#### Following links
+
+- [ ] <kbd>f</kbd>: start following links
+- [ ] <kbd>F</kbd>: start following links and open in new tab
+- [ ] open link with target='_blank' in new tab by <kbd>f</kbd>
+- [ ] open link with target='_blank' in new tab by <kbd>F</kbd>
+- [ ] Show hints on following on a page containing `<frame>`/`<iframe>`
+- [ ] Show hints only inside viewport of the frame on following on a page containing `<frame>`/`<iframe>`
+- [ ] Show hints only inside top window on following on a page containing `<frame>`/`<iframe>`
+- [ ] Select link and open it in the frame in `<iframe>`/`<frame`> on following by <kbd>f</kbd>
+- [ ] Select link and open it in new tab in `<iframe>`/`<frame`> on following by <kbd>F</kbd>
 
 #### Consoles
 
@@ -72,6 +83,7 @@ The behaviors of the console are tested in [Console section](#consoles).
 
 #### Completions
 
+
 ##### History and search engines
 
 - [ ] `open`: show no completions
@@ -80,6 +92,7 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] `open foo bar`: complete history items matched with keywords `foo` and `bar`
 - [ ] also `tabopen` and `winopen`
 - shortening commands such as `o` are not test in this release
+- [ ] Show competions for `:open`/`:tabopen`/`:buffer` on opning just after closed
 
 ##### Buffer command
 
@@ -94,13 +107,21 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] show error on invalid json
 - [ ] show error when top-level keys has keys other than `keymaps`, `search`, and `blacklist`
 
-##### `"keymaps"` section
+###### `"keymaps"` section
 
 - [ ] show error on unknown operation name in `"keymaps"`
 
-##### `"search"` section
+###### `"search"` section
 
 - validations in `"search"` section are not tested in this release
+
+##### `"blacklist"` section
+
+- [ ] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
+- [ ] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
+- [ ] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
+- [ ] `github.com` blocks both `github.com/` and `github.com/a`
+- [ ] `*.github.com` blocks `gist.github.com/`, and not `github.com`
 
 ##### Updating
 
@@ -109,40 +130,8 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] keymap settings are applied to open tabs without reload
 - [ ] search settings are applied to open tabs without reload
 
-#### Events are fired on Slack and Twitter (#54)
-
-- [ ] Fucus text box on Twitter or Slack, press <kbd>j</kbd>, then <kbd>j</kbd> is typed in the box
-- [ ] Focus the text box on Twitter or Slack on following mode
-
-#### Multi frame support (#61)
-
-- [ ] Show hints on following on a page containing `<frame>`/`<iframe>`
-- [ ] Show hints only inside viewport of the frame on following on a page containing `<frame>`/`<iframe>`
-- [ ] Show hints only inside top window on following on a page containing `<frame>`/`<iframe>`
-- [ ] Select link and open it in the frame in `<iframe>`/`<frame`> on following by <kbd>f</kbd>
-- [ ] Select link and open it in new tab in `<iframe>`/`<frame`> on following by <kbd>F</kbd>
-
-#### Empty suggestion (#65)
-
-- [ ] Show competions for `:open`/`:tabopen`/`:buffer` on console after closed
-
-#### Disable add-on temporary (#86)
-
-- [ ] Toggle enabled/disabled of plugin bu <kbd>Shift</kbd>+<kbd>Esc</kbd>
-
-#### URL blacklist (#90)
-
-- [ ] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
-- [ ] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
-- [ ] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
-- [ ] `github.com` blocks both `github.com/` and `github.com/a`
-- [ ] `*.github.com` blocks `gist.github.com/`, and not `github.com`
-
-#### Improve for aberration pages (#93)
+#### For certain sites
 
 - [ ] able to scroll on Gmail and Slack
-
-#### Link with target='_blank' link (#94)
-
-- [ ] open link with target='_blank' in new tab by <kbd>f</kbd>
-- [ ] open link with target='_blank' in new tab by <kbd>F</kbd>
+- [ ] Fucus text box on Twitter or Slack, press <kbd>j</kbd>, then <kbd>j</kbd> is typed in the box
+- [ ] Focus the text box on Twitter or Slack on following mode


### PR DESCRIPTION
## Checklist for testing Vim Vixen

### Operations

Test operations with default key maps.

#### Scrolling

- [x] <kbd>k</kbd> or <kbd>Ctrl</kbd>+<kbd>Y</kbd>, <kbd>j</kbd> or <kbd>Ctrl</kbd>+<kbd>E</kbd>: scroll up and down
- [x] <kbd>h</kbd>, <kbd>l</kbd>: scroll left and right
- [x] <kbd>Ctrl</kbd>+<kbd>U</kbd>, <kbd>Ctrl</kbd>+<kbd>D</kbd>: scroll up and down by half of screen
- [x] <kbd>Ctrl</kbd>+<kbd>B</kbd>, <kbd>Ctrl</kbd>+<kbd>F</kbd>: scroll up and down by a screen
- [x] <kbd>0</kbd>, <kbd>$</kbd>: scroll to leftmost and rightmost
- [x] <kbd>g</kbd><kbd>g</kbd>, <kbd>G</kbd>: scroll to top and bottom

#### Console

The behaviors of the console are tested in [Console section](#consoles).

- [x] <kbd>:</kbd>: open empty console
- [x] <kbd>o</kbd>, <kbd>t</kbd>, <kbd>w</kbd>: open a console with `open`, `tabopen`, `winopen`
- [x] <kbd>O</kbd>, <kbd>T</kbd>, <kbd>W</kbd>: open a console with `open`, `tabopen`, `winopen` and current URL
- [x] <kbd>b</kbd>: open a consolw with `buffer`

#### Tabs

- [x] <kbd>d</kbd>: delete current tab
- [x] <kbd>u</kbd>: reopen close tab
- [x] <kbd>K</kbd>, <kbd>J</kbd>: select prev and next tab
- [x] <kbd>r</kbd>: reload current tab
- [x] <kbd>R</kbd>: reload current tab without cache

#### Navigation

- [x] <kbd>H</kbd>, <kbd>L</kbd>: go back and forward in histories
- [x] <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: find prev and next links and open it
- [x] <kbd>g</kbd><kbd>u</kbd>: go to parent directory
- [x] <kbd>g</kbd><kbd>U</kbd>: go to root directory

#### Misc

- [x] <kbd>z</kbd><kbd>i</kbd>, <kbd>z</kbd><kbd>o</kbd>: zoom-in and zoom-out
- [x] <kbd>z</kbd><kbd>z</kbd>: set zoom level as default
- [x] <kbd>y</kbd>: yank current URL and show a message
- [x] Toggle enabled/disabled of plugin bu <kbd>Shift</kbd>+<kbd>Esc</kbd>

### Following links

- [x] <kbd>f</kbd>: start following links
- [x] <kbd>F</kbd>: start following links and open in new tab
- [x] open link with target='_blank' in new tab by <kbd>f</kbd>
- [x] open link with target='_blank' in new tab by <kbd>F</kbd>
- [x] Show hints on following on a page containing `<frame>`/`<iframe>`
- [x] Show hints only inside viewport of the frame on following on a page containing `<frame>`/`<iframe>`
- [x] Show hints only inside top window on following on a page containing `<frame>`/`<iframe>`
- [x] Select link and open it in the frame in `<iframe>`/`<frame`> on following by <kbd>f</kbd>
- [x] Select link and open it in new tab in `<iframe>`/`<frame`> on following by <kbd>F</kbd>
- [x] Select link and open it in `<area>` tags, for <kbd>f</kbd> and <kbd>F</kbd>

### Consoles

#### Exec a command

- [x] `<EMPTY>`, `<SP>`: do nothing
<br>

- [x] `open an apple`: search with keywords "an apple" by default search engine (google)
- [x] `open github.com`: open github.com
- [x] `open https://github.com`: open github.com
- [x] `open yahoo an apple`: search with keywords "an apple" by yahoo.com
- [x] `open yahoo`,`open yahoo<SP>`: search with empty keywords; yahoo redirects to top page
- [x] `open`,`open<SP>`: open default search engine
<br>

- [x] `tabopen`: do avobe tests replaced `open` with `tabopen`, and verify the page is opened in new tab
- [x] `winopen`: do avobe tests replaced `open` with `winopen`, and verify the page is opened in new window
<br>

- [x] `buffer`,`buffer<SP>`: do nothing
- [x] `buffer <title>`, `buffer <url>`: select tab which has an title matched with
- [x] `buffer 1`: select leftmost tab
- [x] `buffer 0`, `buffer 99`: shows an error
- [x] select tabs rotationally when more than two tabs are matched

### Completions

#### History and search engines

- [x] `open`: show no completions
- [x] `open<SP>`: show all engines and some history items
- [x] `open g`: complete search engines starts with `g` and matched with keywords `g`
- [x] `open foo bar`: complete history items matched with keywords `foo` and `bar`
- [x] also `tabopen` and `winopen`
- shortening commands such as `o` are not test in this release
- [x] Show competions for `:open`/`:tabopen`/`:buffer` on opning just after closed

#### Buffer command

- [x] `buffer`: show no completions
- [x] `buffer<SP>`: show all opened tabs in completion
- [x] `buffer x`: show tabs which has title and URL matches with `x`

#### Misc

- [x] Select next item by <kbd>Tab</kbd> and previous item by <kbd>Shift</kbd>+<kbd>Tab</kbd>

### Settings

#### Validations

- [x] show error on invalid json
- [x] show error when top-level keys has keys other than `keymaps`, `search`, and `blacklist`

##### `"keymaps"` section

- [x] show error on unknown operation name in `"keymaps"`

##### `"search"` section

- validations in `"search"` section are not tested in this release

#### `"blacklist"` section

- [x] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
- [x] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
- [x] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
- [x] `github.com` blocks both `github.com/` and `github.com/a`
- [x] `*.github.com` blocks `gist.github.com/`, and not `github.com`

#### Updating

- [x] changes are updated on textarea blure when no errors
- [x] changes are not updated on textarea blure when errors occurs
- [x] keymap settings are applied to open tabs without reload
- [x] search settings are applied to open tabs without reload

### For certain sites

- [x] scoll on Hacker News
- [x] able to scroll on Gmail and Slack
- [x] Fucus text box on Twitter or Slack, press <kbd>j</kbd>, then <kbd>j</kbd> is typed in the box
- [x] Focus the text box on Twitter or Slack on following mode

## Misc

- [x] Work after plugin reload