### PR TITLE
Add c-n, c-j, c-p, c-k, c-m to console keybind

### DIFF
--- a/src/console/components/console.js
+++ b/src/console/components/console.js
@@ -71,7 +71,7 @@ export default class ConsoleComponent {
       break;
     case KeyboardEvent.DOM_VK_M:
       if (e.ctrlKey) {
-        this.doEnter(e);
+        return this.doEnter(e);
       }
       break;
     case KeyboardEvent.DOM_VK_DOWN:

--- a/src/console/components/console.js
+++ b/src/console/components/console.js
@@ -48,6 +48,34 @@ export default class ConsoleComponent {
       e.stopPropagation();
       e.preventDefault();
       break;
+    case KeyboardEvent.DOM_VK_OPEN_BRACKET:
+      if (e.ctrlKey) {
+        return this.hideCommand();
+      }
+      break;
+    case KeyboardEvent.DOM_VK_M:
+      if (e.ctrlKey) {
+        e.stopPropagation();
+        e.preventDefault();
+        return this.onEntered(e.target.value);
+      }
+      break;
+    case KeyboardEvent.DOM_VK_N:
+    case KeyboardEvent.DOM_VK_J:
+      if (e.ctrlKey) {
+        this.store.dispatch(consoleActions.completionNext());
+        e.stopPropagation();
+        e.preventDefault();
+      }
+      break;
+    case KeyboardEvent.DOM_VK_P:
+    case KeyboardEvent.DOM_VK_K:
+      if (e.ctrlKey) {
+        this.store.dispatch(consoleActions.completionPrev());
+        e.stopPropagation();
+        e.preventDefault();
+      }
+      break;
     }
   }
 

--- a/src/console/components/console.js
+++ b/src/console/components/console.js
@@ -78,7 +78,6 @@ export default class ConsoleComponent {
       this.selectNext(e);
       break;
     case KeyboardEvent.DOM_VK_N:
-    case KeyboardEvent.DOM_VK_J:
       if (e.ctrlKey) {
         this.selectNext(e);
       }
@@ -87,7 +86,6 @@ export default class ConsoleComponent {
       this.selectPrev(e);
       break;
     case KeyboardEvent.DOM_VK_P:
-    case KeyboardEvent.DOM_VK_K:
       if (e.ctrlKey) {
         this.selectPrev(e);
       }

--- a/src/console/components/console.js
+++ b/src/console/components/console.js
@@ -31,14 +31,30 @@ export default class ConsoleComponent {
     }
   }
 
+  doEnter(e) {
+    e.stopPropagation();
+    e.preventDefault();
+    return this.onEntered(e.target.value);
+  }
+
+  selectNext(e) {
+    this.store.dispatch(consoleActions.completionNext());
+    e.stopPropagation();
+    e.preventDefault();
+  }
+
+  selectPrev(e) {
+    this.store.dispatch(consoleActions.completionPrev());
+    e.stopPropagation();
+    e.preventDefault();
+  }
+
   onKeyDown(e) {
     switch (e.keyCode) {
     case KeyboardEvent.DOM_VK_ESCAPE:
       return this.hideCommand();
     case KeyboardEvent.DOM_VK_RETURN:
-      e.stopPropagation();
-      e.preventDefault();
-      return this.onEntered(e.target.value);
+      return this.doEnter(e);
     case KeyboardEvent.DOM_VK_TAB:
       if (e.shiftKey) {
         this.store.dispatch(consoleActions.completionPrev());
@@ -55,25 +71,25 @@ export default class ConsoleComponent {
       break;
     case KeyboardEvent.DOM_VK_M:
       if (e.ctrlKey) {
-        e.stopPropagation();
-        e.preventDefault();
-        return this.onEntered(e.target.value);
+        this.doEnter(e);
       }
+      break;
+    case KeyboardEvent.DOM_VK_DOWN:
+      this.selectNext(e);
       break;
     case KeyboardEvent.DOM_VK_N:
     case KeyboardEvent.DOM_VK_J:
       if (e.ctrlKey) {
-        this.store.dispatch(consoleActions.completionNext());
-        e.stopPropagation();
-        e.preventDefault();
+        this.selectNext(e);
       }
+      break;
+    case KeyboardEvent.DOM_VK_UP:
+      this.selectPrev(e);
       break;
     case KeyboardEvent.DOM_VK_P:
     case KeyboardEvent.DOM_VK_K:
       if (e.ctrlKey) {
-        this.store.dispatch(consoleActions.completionPrev());
-        e.stopPropagation();
-        e.preventDefault();
+        this.selectPrev(e);
       }
       break;
     }

--- a/src/console/components/console.js
+++ b/src/console/components/console.js
@@ -74,16 +74,10 @@ export default class ConsoleComponent {
         return this.doEnter(e);
       }
       break;
-    case KeyboardEvent.DOM_VK_DOWN:
-      this.selectNext(e);
-      break;
     case KeyboardEvent.DOM_VK_N:
       if (e.ctrlKey) {
         this.selectNext(e);
       }
-      break;
-    case KeyboardEvent.DOM_VK_UP:
-      this.selectPrev(e);
       break;
     case KeyboardEvent.DOM_VK_P:
       if (e.ctrlKey) {


### PR DESCRIPTION
Hi, first thank you for create nice and useful extension!

I add following behaviors to Vim-vixen.

- `c-n`, ~~`c-j`~~ for select next item.
- `c-p`, ~~`c-k`~~ for select previous item.
- `c-m` for select item.

These console keybinds are same as Vim(Vimperator)'s completion selector.

Please check and review this and it's very pleasure to give me advices.

Thank you.