### PR TITLE
Reload all tabs

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -36,6 +36,7 @@ The behaviors of the console are tested in [Console section](#consoles).
 #### Navigation
 
 - [ ] <kbd>H</kbd>, <kbd>L</kbd>: go back and forward in histories
+- [ ] <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: Open next/prev link in `<link>` tags.
 - [ ] <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: find prev and next links and open it
 - [ ] <kbd>g</kbd><kbd>u</kbd>: go to parent directory
 - [ ] <kbd>g</kbd><kbd>U</kbd>: go to root directory
@@ -143,11 +144,13 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] able to scroll on Gmail and Slack
 - [ ] Fucus text box on Twitter or Slack, press <kbd>j</kbd>, then <kbd>j</kbd> is typed in the box
 - [ ] Focus the text box on Twitter or Slack on following mode
+- [ ] Tha pages is shown in https://pitchify.com/
+- [ ] Open console in http://www.espncricinfo.com/
 
 ## Find mode
 
 - [ ] open console with <kbd>/</kbd>
-- [ ] highlight a word on <kbd>Enter</kb> pressed in find console
+- [ ] highlight a word on <kbd>Enter</kbd> pressed in find console
 - [ ] Search next/prev by <kbd>n</kbd>/<kbd>N</kbd>
 - [ ] Wrap search by <kbd>n</kbd>/<kbd>N</kbd>
 - [ ] Find with last keyword if keyword is empty

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The default mappings are as follows:
 - <kbd>g0</kbd>, <kbd>g$</kbd>: select first or last tab
 - <kbd>r</kbd>: reload current tab
 - <kbd>R</kbd>: reload current tab without cache
+- <kbd>ar</kbd>: reload all tabs
+- <kbd>aR</kbd>: reload all tabs without cache
 - <kbd>zp</kbd>: toggle pin/unpin current tab
 - <kbd>zd</kbd>: duplicate current tab
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Vim Vixen",
   "description": "Vim Vixen",
-  "version": "0.5",
+  "version": "0.6",
   "icons": {
     "48": "resources/icon_48x48.png",
     "96": "resources/icon_96x96.png"

--- a/src/background/actions/operation.js
+++ b/src/background/actions/operation.js
@@ -29,6 +29,8 @@ const exec = (operation, tab) => {
     return tabs.selectLastTab();
   case operations.TAB_RELOAD:
     return tabs.reload(tab, operation.cache);
+  case operations.TAB_RELOAD_ALL:
+    return tabs.reloadAll(tab, operation.cache);
   case operations.TAB_PIN:
     return tabs.updateTabPinned(tab, true);
   case operations.TAB_UNPIN:

--- a/src/background/tabs.js
+++ b/src/background/tabs.js
@@ -100,6 +100,14 @@ const reload = (current, cache) => {
   );
 };
 
+const reloadAll = (current, cache) => {
+  return browser.tabs.query({ currentWindow: true }).then((tabs) => {
+    for (let tab of tabs) {
+      browser.tabs.reload(tab.id, { bypassCache: cache });
+    }
+  });
+};
+
 const updateTabPinned = (current, pinned) => {
   return browser.tabs.query({ currentWindow: true, active: true })
     .then(() => {
@@ -118,5 +126,5 @@ const duplicate = (id) => {
 export {
   closeTab, reopenTab, selectAt, selectByKeyword, getCompletions,
   selectPrevTab, selectNextTab, selectFirstTab, selectLastTab, reload,
-  updateTabPinned, toggleTabPinned, duplicate
+  reloadAll, updateTabPinned, toggleTabPinned, duplicate
 };

--- a/src/console/site.scss
+++ b/src/console/site.scss
@@ -69,6 +69,8 @@ body {
 
   &-message {
     @include consoole-font;
+
+    border-top: 1px solid gray;
   }
 
   &-error {

--- a/src/shared/default-settings.js
+++ b/src/shared/default-settings.js
@@ -32,6 +32,8 @@ export default {
     "g$": { "type": "tabs.last" },
     "r": { "type": "tabs.reload", "cache": false },
     "R": { "type": "tabs.reload", "cache": true },
+    "ar": { "type": "tabs.reloadAll", "cache": false },
+    "aR": { "type": "tabs.reloadAll", "cache": true },
     "zp": { "type": "tabs.pin.toggle" },
     "zd": { "type": "tabs.duplicate" },
     "zi": { "type": "zoom.in" },

--- a/src/shared/operations.js
+++ b/src/shared/operations.js
@@ -39,6 +39,7 @@ export default {
   TAB_FIRST: 'tabs.first',
   TAB_LAST: 'tabs.last',
   TAB_RELOAD: 'tabs.reload',
+  TAB_RELOAD_ALL: 'tabs.reloadAll',
   TAB_PIN: 'tabs.pin',
   TAB_UNPIN: 'tabs.unpin',
   TAB_TOGGLE_PINNED: 'tabs.pin.toggle',


### PR DESCRIPTION
# Reload all tabs

According to my feature request ([#205](https://github.com/ueokande/vim-vixen/issues/205)) I added the functionality to reload all tabs in the current window by myself and want to share this improvement.
I chose `ar` and `aR` for the default binding like [VimFx](https://addons.mozilla.org/en-US/firefox/addon/vimfx/).

![](https://media.giphy.com/media/3o6fJ9UxgRJ5dYGeKk/giphy.gif)

### Tests
```
$ npm run test
[...]
SUMMARY:
✔ 117 tests completed
$ npm run lint
$
```