### PR TITLE
QA 0.6

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -150,7 +150,7 @@ The behaviors of the console are tested in [Console section](#consoles).
 ## Find mode
 
 - [ ] open console with <kbd>/</kbd>
-- [ ] highlight a word on <kbd>Enter</kb> pressed in find console
+- [ ] highlight a word on <kbd>Enter</kbd> pressed in find console
 - [ ] Search next/prev by <kbd>n</kbd>/<kbd>N</kbd>
 - [ ] Wrap search by <kbd>n</kbd>/<kbd>N</kbd>
 - [ ] Find with last keyword if keyword is empty

--- a/QA.md
+++ b/QA.md
@@ -36,7 +36,7 @@ The behaviors of the console are tested in [Console section](#consoles).
 #### Navigation
 
 - [ ] <kbd>H</kbd>, <kbd>L</kbd>: go back and forward in histories
-- [ ] <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: Open next/prev link in <link> tags.
+- [ ] <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: Open next/prev link in `<link>` tags.
 - [ ] <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: find prev and next links and open it
 - [ ] <kbd>g</kbd><kbd>u</kbd>: go to parent directory
 - [ ] <kbd>g</kbd><kbd>U</kbd>: go to root directory

--- a/QA.md
+++ b/QA.md
@@ -36,6 +36,7 @@ The behaviors of the console are tested in [Console section](#consoles).
 #### Navigation
 
 - [ ] <kbd>H</kbd>, <kbd>L</kbd>: go back and forward in histories
+- [ ] <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: Open next/prev link in <link> tags.
 - [ ] <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: find prev and next links and open it
 - [ ] <kbd>g</kbd><kbd>u</kbd>: go to parent directory
 - [ ] <kbd>g</kbd><kbd>U</kbd>: go to root directory
@@ -143,6 +144,8 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] able to scroll on Gmail and Slack
 - [ ] Fucus text box on Twitter or Slack, press <kbd>j</kbd>, then <kbd>j</kbd> is typed in the box
 - [ ] Focus the text box on Twitter or Slack on following mode
+- [ ] Tha pages is shown in https://pitchify.com/
+- [ ] Open console in http://www.espncricinfo.com/
 
 ## Find mode
 

--- a/src/console/site.scss
+++ b/src/console/site.scss
@@ -69,6 +69,8 @@ body {
 
   &-message {
     @include consoole-font;
+
+    border-top: 1px solid gray;
   }
 
   &-error {


### PR DESCRIPTION
## Checklist for testing Vim Vixen

### Operations

Test operations with default key maps.

#### Scrolling

- [x] <kbd>k</kbd> or <kbd>Ctrl</kbd>+<kbd>Y</kbd>, <kbd>j</kbd> or <kbd>Ctrl</kbd>+<kbd>E</kbd>: scroll up and down
- [x] <kbd>h</kbd>, <kbd>l</kbd>: scroll left and right
- [x] <kbd>Ctrl</kbd>+<kbd>U</kbd>, <kbd>Ctrl</kbd>+<kbd>D</kbd>: scroll up and down by half of screen
- [x] <kbd>Ctrl</kbd>+<kbd>B</kbd>, <kbd>Ctrl</kbd>+<kbd>F</kbd>: scroll up and down by a screen
- [x] <kbd>0</kbd>, <kbd>$</kbd>: scroll to leftmost and rightmost
- [x] <kbd>g</kbd><kbd>g</kbd>, <kbd>G</kbd>: scroll to top and bottom

#### Console

The behaviors of the console are tested in [Console section](#consoles).

- [x] <kbd>:</kbd>: open empty console
- [x] <kbd>o</kbd>, <kbd>t</kbd>, <kbd>w</kbd>: open a console with `open`, `tabopen`, `winopen`
- [x] <kbd>O</kbd>, <kbd>T</kbd>, <kbd>W</kbd>: open a console with `open`, `tabopen`, `winopen` and current URL
- [x] <kbd>b</kbd>: open a consolw with `buffer`

#### Tabs

- [x] <kbd>d</kbd>: delete current tab
- [x] <kbd>u</kbd>: reopen close tab
- [x] <kbd>K</kbd>, <kbd>J</kbd>: select prev and next tab
- [x] <kbd>g0</kbd>, <kbd>g$</kbd>: select first and last tab
- [x] <kbd>r</kbd>: reload current tab
- [x] <kbd>R</kbd>: reload current tab without cache
- [x] <kbd>zd</kbd>: duplicate current tab
- [x] <kbd>zp</kbd>: toggle pin/unpin state on current tab

#### Navigation

- [x] <kbd>H</kbd>, <kbd>L</kbd>: go back and forward in histories
- [x] <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: Open next/prev link in `<link>` tags.
- [x] <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: find prev and next links and open it
- [x] <kbd>g</kbd><kbd>u</kbd>: go to parent directory
- [x] <kbd>g</kbd><kbd>U</kbd>: go to root directory

#### Misc

- [x] <kbd>z</kbd><kbd>i</kbd>, <kbd>z</kbd><kbd>o</kbd>: zoom-in and zoom-out
- [x] <kbd>z</kbd><kbd>z</kbd>: set zoom level as default
- [x] <kbd>y</kbd>: yank current URL and show a message
- [x] Toggle enabled/disabled of plugin bu <kbd>Shift</kbd>+<kbd>Esc</kbd>

### Following links

- [x] <kbd>f</kbd>: start following links
- [x] <kbd>F</kbd>: start following links and open in new tab
- [x] open link with target='_blank' in new tab by <kbd>f</kbd>
- [x] open link with target='_blank' in new tab by <kbd>F</kbd>
- [x] Show hints on following on a page containing `<frame>`/`<iframe>`
- [x] Show hints only inside viewport of the frame on following on a page containing `<frame>`/`<iframe>`
- [x] Show hints only inside top window on following on a page containing `<frame>`/`<iframe>`
- [x] Select link and open it in the frame in `<iframe>`/`<frame`> on following by <kbd>f</kbd>
- [x] Select link and open it in new tab in `<iframe>`/`<frame`> on following by <kbd>F</kbd>
- [x] Select link and open it in `<area>` tags, for <kbd>f</kbd> and <kbd>F</kbd>

### Consoles

#### Exec a command

- [x] `<EMPTY>`, `<SP>`: do nothing
<br>

- [x] `open an apple`: search with keywords "an apple" by default search engine (google)
- [x] `open github.com`: open github.com
- [x] `open https://github.com`: open github.com
- [x] `open yahoo an apple`: search with keywords "an apple" by yahoo.com
- [x] `open yahoo`,`open yahoo<SP>`: search with empty keywords; yahoo redirects to top page
- [x] `open`,`open<SP>`: open default search engine
<br>

- [x] `tabopen`: do avobe tests replaced `open` with `tabopen`, and verify the page is opened in new tab
- [x] `winopen`: do avobe tests replaced `open` with `winopen`, and verify the page is opened in new window
<br>

- [x] `buffer`,`buffer<SP>`: do nothing
- [x] `buffer <title>`, `buffer <url>`: select tab which has an title matched with
- [x] `buffer 1`: select leftmost tab
- [x] `buffer 0`, `buffer 99`: shows an error
- [x] select tabs rotationally when more than two tabs are matched

### Completions

#### History and search engines

- [x] `open`: show no completions
- [x] `open<SP>`: show all engines and some history items
- [x] `open g`: complete search engines starts with `g` and matched with keywords `g`
- [x] `open foo bar`: complete history items matched with keywords `foo` and `bar`
- [x] also `tabopen` and `winopen`
- shortening commands such as `o` are not test in this release
- [x] Show competions for `:open`/`:tabopen`/`:buffer` on opning just after closed

#### Buffer command

- [x] `buffer`: show no completions
- [x] `buffer<SP>`: show all opened tabs in completion
- [x] `buffer x`: show tabs which has title and URL matches with `x`

#### Misc

- [x] Select next item by <kbd>Tab</kbd> and previous item by <kbd>Shift</kbd>+<kbd>Tab</kbd>

### Settings

#### Validations

- [x] show error on invalid json
- [x] show error when top-level keys has keys other than `keymaps`, `search`, and `blacklist`

##### `"keymaps"` section

- [x] show error on unknown operation name in `"keymaps"`

##### `"search"` section

- validations in `"search"` section are not tested in this release

#### `"blacklist"` section

- [x] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
- [x] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
- [x] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
- [x] `github.com` blocks both `github.com/` and `github.com/a`
- [x] `*.github.com` blocks `gist.github.com/`, and not `github.com`

#### Updating

- [x] changes are updated on textarea blure when no errors
- [x] changes are not updated on textarea blure when errors occurs
- [x] keymap settings are applied to open tabs without reload
- [x] search settings are applied to open tabs without reload

### For certain sites

- [x] scoll on Hacker News
- [x] able to scroll on Gmail and Slack
- [x] Fucus text box on Twitter or Slack, press <kbd>j</kbd>, then <kbd>j</kbd> is typed in the box
- [x] Focus the text box on Twitter or Slack on following mode
- [x] Tha pages is shown in https://pitchify.com/
- [x] Open console in http://www.espncricinfo.com/

## Find mode

- [x] open console with <kbd>/</kbd>
- [x] highlight a word on <kbd>Enter</kb> pressed in find console
- [x] Search next/prev by <kbd>n</kbd>/<kbd>N</kbd>
- [x] Wrap search by <kbd>n</kbd>/<kbd>N</kbd>
- [x] Find with last keyword if keyword is empty

## Misc

- [x] Work after plugin reload
- [x] Work on `about:blank`
- [x] Able to map `<A-Z>` key.
- [x] Open file menu by <kbd>Alt</kbd>+<kbd>F</kbd> (Other than Mac OS)