### PR TITLE
Fix history completion to show most frequent results first.

### DIFF
--- a/src/background/histories.js
+++ b/src/background/histories.js
@@ -76,7 +76,6 @@ const getCompletions = (keyword) => {
         .sort((x, y) => x[0].visitCount < y[0].visitCount)
         .slice(0, 10)
         .map(item => item[0])
-        .sort((x, y) => x.url > y.url)
       )[0];
   });
 };


### PR DESCRIPTION
Display most visited completion results first.

It should fix #188 