### PR TITLE
Fix buffers completion when there are some tabs with undefined title.

### DIFF
--- a/src/background/tabs.js
+++ b/src/background/tabs.js
@@ -51,7 +51,7 @@ const selectByKeyword = (current, keyword) => {
 const getCompletions = (keyword) => {
   return browser.tabs.query({ currentWindow: true }).then((tabs) => {
     let matched = tabs.filter((t) => {
-      return t.url.includes(keyword) || t.title.includes(keyword);
+      return t.url.includes(keyword) || t.title && t.title.includes(keyword);
     });
     return matched;
   });


### PR DESCRIPTION
Seems like in some cases tabs could have an undefined value in title (maybe when they were not properly loaded).