### PR TITLE
Closing pinned tabs must be forced

### DIFF
--- a/src/background/actions/operation.js
+++ b/src/background/actions/operation.js
@@ -17,6 +17,8 @@ const exec = (operation, tab) => {
   switch (operation.type) {
   case operations.TAB_CLOSE:
     return tabs.closeTab(tab.id);
+  case operations.TAB_CLOSE_FORCE:
+    return tabs.closeTabForce(tab.id);
   case operations.TAB_REOPEN:
     return tabs.reopenTab();
   case operations.TAB_PREV:

--- a/src/background/tabs.js
+++ b/src/background/tabs.js
@@ -10,10 +10,10 @@ browser.tabs.onActivated.addListener((activeInfo) => {
 
 const closeTab = (id) => {
   return browser.tabs.get(id).then((tab) => {
-    if(!tab.pinned) {
+    if (!tab.pinned) {
       return browser.tabs.remove(id);
     }
-  })
+  });
 };
 
 const closeTabForce = (id) => {

--- a/src/background/tabs.js
+++ b/src/background/tabs.js
@@ -9,6 +9,14 @@ browser.tabs.onActivated.addListener((activeInfo) => {
 });
 
 const closeTab = (id) => {
+  return browser.tabs.get(id).then((tab) => {
+    if(!tab.pinned) {
+      return browser.tabs.remove(id);
+    }
+  })
+};
+
+const closeTabForce = (id) => {
   return browser.tabs.remove(id);
 };
 
@@ -130,7 +138,8 @@ const duplicate = (id) => {
 };
 
 export {
-  closeTab, reopenTab, selectAt, selectByKeyword, getCompletions,
-  selectPrevTab, selectNextTab, selectFirstTab, selectLastTab, selectPrevSelTab,
-  reload, updateTabPinned, toggleTabPinned, duplicate
+  closeTab, closeTabForce, reopenTab, selectAt, selectByKeyword,
+  getCompletions, selectPrevTab, selectNextTab, selectFirstTab,
+  selectLastTab, selectPrevSelTab, reload, updateTabPinned,
+  toggleTabPinned, duplicate
 };

--- a/src/shared/operations.js
+++ b/src/shared/operations.js
@@ -33,6 +33,7 @@ export default {
 
   // Tabs
   TAB_CLOSE: 'tabs.close',
+  TAB_CLOSE_FORCE: 'tabs.close.force',
   TAB_REOPEN: 'tabs.reopen',
   TAB_PREV: 'tabs.prev',
   TAB_NEXT: 'tabs.next',

--- a/src/shared/settings/default.js
+++ b/src/shared/settings/default.js
@@ -23,7 +23,7 @@ export default {
     "G": { "type": "scroll.bottom" },
     "$": { "type": "scroll.end" },
     "d": { "type": "tabs.close" },
-    "DD": { "type": "tabs.close.force" },
+    "!d": { "type": "tabs.close.force" },
     "u": { "type": "tabs.reopen" },
     "K": { "type": "tabs.prev", "count": 1 },
     "J": { "type": "tabs.next", "count": 1 },

--- a/src/shared/settings/default.js
+++ b/src/shared/settings/default.js
@@ -23,6 +23,7 @@ export default {
     "G": { "type": "scroll.bottom" },
     "$": { "type": "scroll.end" },
     "d": { "type": "tabs.close" },
+    "DD": { "type": "tabs.close.force" },
     "u": { "type": "tabs.reopen" },
     "K": { "type": "tabs.prev", "count": 1 },
     "J": { "type": "tabs.next", "count": 1 },


### PR DESCRIPTION
According to #229 pinned tabs now can only be closed with `DD` which forces close without any check. In contrast `d` will now check whether the tab is pinned or not and will only close regular tabs.