### PR TITLE
do not follow link which has aria-hidden attribute or aria-disabled a…

### DIFF
--- a/src/content/components/common/follow.js
+++ b/src/content/components/common/follow.js
@@ -30,6 +30,21 @@ const inViewport = (win, element, viewSize, framePosition) => {
   return true;
 };
 
+const isAriaHiddenOrAriaDisabled = (win, element) => {
+  if (!element || win.document.documentElement === element) {
+    return false;
+  }
+  for (let attr of ['aria-hidden', 'aria-disabled']) {
+    if (element.hasAttribute(attr)) {
+      let hidden = element.getAttribute(attr).toLowerCase();
+      if (hidden === '' || hidden === 'true') {
+        return true;
+      }
+    }
+  }
+  return isAriaHiddenOrAriaDisabled(win, element.parentNode);
+};
+
 export default class Follow {
   constructor(win, store) {
     this.win = win;
@@ -171,6 +186,7 @@ export default class Follow {
         style.visibility !== 'hidden' &&
         element.type !== 'hidden' &&
         element.offsetHeight > 0 &&
+        !isAriaHiddenOrAriaDisabled(win, element) &&
         inViewport(win, element, viewSize, framePosition);
     });
     return filtered;


### PR DESCRIPTION
Now, follow.start does not follow link which has aria-hidden attribute or aria-disabled attribute.

# old follow.start

![before](https://user-images.githubusercontent.com/291273/34322780-7cef3acc-e874-11e7-9669-56ec6216393f.png)

# new follow.start

![after](https://user-images.githubusercontent.com/291273/34322781-87607282-e874-11e7-9155-167a8702346a.png)
