### PR TITLE
support making package on FreeBSD

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+GREP=grep
+if grep --version | grep -- '-FreeBSD' >/dev/null; then
+  if [ ! -x /usr/local/bin/grep ]; then
+    echo 'GNU grep not found' >&2
+    exit 1
+  fi
+  # use GNU grep instead of BSD grep which does not support PCRE
+  GREP=/usr/local/bin/grep
+fi
+
 MANIFEST="manifest.json"
 
 version=$(jq -r '.version' $MANIFEST)
@@ -11,7 +21,7 @@ web_accessible_resources=$(jq -r '.web_accessible_resources[]' $MANIFEST)
 options_ui=$(jq -r '.options_ui.page' $MANIFEST)
 options_scripts=""
 for html in $options_ui; do
-  scripts=$(grep -Po "(?<=src=['\"])[^'\"]*" "$html")
+  scripts=$(${GREP} -Po "(?<=src=['\"])[^'\"]*" "$html")
   for js in $scripts; do
     options_scripts="$options_scripts $(dirname $html)/$js"
   done


### PR DESCRIPTION
This commit makes package.sh to use GNU grep instead of BSD grep which does not support PCRE.