### PR TITLE
add follow.copy feature to copy a link URL/text

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,8 @@
     "history",
     "sessions",
     "storage",
-    "tabs"
+    "tabs",
+    "clipboardWrite"
   ],
   "web_accessible_resources": [
     "build/console.html",

--- a/src/content/actions/follow-controller.js
+++ b/src/content/actions/follow-controller.js
@@ -1,9 +1,11 @@
 import actions from 'content/actions';
 
-const enable = (newTab) => {
+const enable = (operation, newTab, format) => {
   return {
     type: actions.FOLLOW_CONTROLLER_ENABLE,
+    operation,
     newTab,
+    format,
   };
 };
 

--- a/src/content/actions/operation.js
+++ b/src/content/actions/operation.js
@@ -42,6 +42,11 @@ const exec = (operation) => {
       type: messages.FOLLOW_START,
       newTab: operation.newTab
     }), '*');
+  case operations.FOLLOW_COPY:
+    return window.top.postMessage(JSON.stringify({
+      type: messages.FOLLOW_COPY,
+      format: operation.format,
+    }), '*');
   case operations.NAVIGATE_HISTORY_PREV:
     return navigates.historyPrev(window);
   case operations.NAVIGATE_HISTORY_NEXT:
@@ -55,7 +60,7 @@ const exec = (operation) => {
   case operations.NAVIGATE_ROOT:
     return navigates.root(window);
   case operations.URLS_YANK:
-    urls.yank(window);
+    urls.yank(window, window.location.href);
     return consoleFrames.postMessage(window.document, {
       type: messages.CONSOLE_SHOW_INFO,
       text: 'Current url yanked',

--- a/src/content/components/top-content/follow-controller.js
+++ b/src/content/components/top-content/follow-controller.js
@@ -28,8 +28,12 @@ export default class FollowController {
   onMessage(message, sender) {
     switch (message.type) {
     case messages.FOLLOW_START:
-      return this.store.dispatch(
-        followControllerActions.enable(message.newTab));
+    case messages.FOLLOW_COPY:
+      return this.store.dispatch(followControllerActions.enable(
+        message.type,
+        message.newTab ? message.newTab : false,
+        message.format ? message.format : '',
+      ));
     case messages.FOLLOW_RESPONSE_COUNT_TARGETS:
       return this.create(message.count, sender);
     case messages.FOLLOW_KEY_PRESS:

--- a/src/content/reducers/follow-controller.js
+++ b/src/content/reducers/follow-controller.js
@@ -2,7 +2,9 @@ import actions from 'content/actions';
 
 const defaultState = {
   enabled: false,
+  operation: '',
   newTab: false,
+  format: '',
   keys: '',
 };
 
@@ -11,7 +13,9 @@ export default function reducer(state = defaultState, action = {}) {
   case actions.FOLLOW_CONTROLLER_ENABLE:
     return Object.assign({}, state, {
       enabled: true,
+      operation: action.operation,
       newTab: action.newTab,
+      format: action.format,
       keys: '',
     });
   case actions.FOLLOW_CONTROLLER_DISABLE:

--- a/src/content/urls.js
+++ b/src/content/urls.js
@@ -1,10 +1,10 @@
-const yank = (win) => {
+const yank = (win, text) => {
   let input = win.document.createElement('input');
   win.document.body.append(input);
 
   input.style.position = 'fixed';
   input.style.top = '-100px';
-  input.value = win.location.href;
+  input.value = text;
   input.select();
 
   win.document.execCommand('copy');

--- a/src/settings/components/form/keymaps-form.jsx
+++ b/src/settings/components/form/keymaps-form.jsx
@@ -30,6 +30,8 @@ const KeyMapFields = [
   ], [
     ['follow.start?{"newTab":false}', 'Follow a link'],
     ['follow.start?{"newTab":true}', 'Follow a link in new tab'],
+    ['follow.copy?{"format":"|url|"}', 'Copy a link URL'],
+    ['follow.copy?{"format":"|text|"}', 'Copy a link text'],
     ['navigate.history.prev', 'Go back in histories'],
     ['navigate.history.next', 'Go forward in histories'],
     ['navigate.link.next', 'Open next link'],

--- a/src/shared/messages.js
+++ b/src/shared/messages.js
@@ -34,6 +34,7 @@ export default {
   CONSOLE_SHOW_FIND: 'console.show.find',
 
   FOLLOW_START: 'follow.start',
+  FOLLOW_COPY: 'follow.copy',
   FOLLOW_REQUEST_COUNT_TARGETS: 'follow.request.count.targets',
   FOLLOW_RESPONSE_COUNT_TARGETS: 'follow.response.count.targets',
   FOLLOW_CREATE_HINTS: 'follow.create.hints',

--- a/src/shared/operations.js
+++ b/src/shared/operations.js
@@ -22,6 +22,7 @@ export default {
 
   // Follows
   FOLLOW_START: 'follow.start',
+  FOLLOW_COPY: 'follow.copy',
 
   // Navigations
   NAVIGATE_HISTORY_PREV: 'navigate.history.prev',

--- a/src/shared/settings/default.js
+++ b/src/shared/settings/default.js
@@ -37,6 +37,8 @@ export default {
     "zz": { "type": "zoom.neutral" },
     "f": { "type": "follow.start", "newTab": false },
     "F": { "type": "follow.start", "newTab": true },
+    "cc": { "type": "follow.copy", "format": "|url|" },
+    "cC": { "type": "follow.copy", "format": "|text|" },
     "H": { "type": "navigate.history.prev" },
     "L": { "type": "navigate.history.next" },
     "[[": { "type": "navigate.link.prev" },

--- a/test/content/actions/follow-controller.test.js
+++ b/test/content/actions/follow-controller.test.js
@@ -5,9 +5,11 @@ import * as followControllerActions from 'content/actions/follow-controller';
 describe('follow-controller actions', () => {
   describe('enable', () => {
     it('creates FOLLOW_CONTROLLER_ENABLE action', () => {
-      let action = followControllerActions.enable(true);
+      let action = followControllerActions.enable('operation', true, 'format');
       expect(action.type).to.equal(actions.FOLLOW_CONTROLLER_ENABLE);
+      expect(action.operation).to.equal('operation');
       expect(action.newTab).to.equal(true);
+      expect(action.format).to.equal('format');
     });
   });
 

--- a/test/content/components/common/follow.test.js
+++ b/test/content/components/common/follow.test.js
@@ -11,11 +11,24 @@ describe('FollowComponent', () => {
       let targets = FollowComponent.getTargetElements(
         window,
         { width: window.innerWidth, height: window.innerHeight },
-        { x: 0, y: 0 });
+        { x: 0, y: 0 },
+        FollowComponent.TARGET_SELECTOR);
       expect(targets).to.have.lengthOf(3);
 
       let ids = Array.prototype.map.call(targets, (e) => e.id);
       expect(ids).to.include.members(['visible_a', 'editable_div_1', 'editable_div_2']);
+    });
+
+    it('returns visible genuine links', () => {
+      let targets = FollowComponent.getTargetElements(
+        window,
+        { width: window.innerWidth, height: window.innerHeight },
+        { x: 0, y: 0 },
+        FollowComponent.LINK_SELECTOR);
+      expect(targets).to.have.lengthOf(1);
+
+      let ids = Array.prototype.map.call(targets, (e) => e.id);
+      expect(ids).to.include.members(['visible_a']);
     });
   });
 });


### PR DESCRIPTION
This commit adds follow.copy feature.
Vim Vixen users can copy a link URL or link text by Follow interface.