### PR TITLE
Add multipication of count property by numeric key

### DIFF
--- a/src/content/components/common/keymapper.js
+++ b/src/content/components/common/keymapper.js
@@ -15,9 +15,41 @@ const mapStartsWith = (mapping, keys) => {
   return true;
 };
 
+const parseKeyInput = (input) => {
+  let countStr = '';
+  let countScale = 1;
+
+  for (let i = 0; i < input.keys.length; i++) {
+    if (input.keys[i].key >= '0' && input.keys[i].key <= '9') {
+      countStr += input.keys[i].key;
+    } else {
+      countScale = parseInt(countStr, 10);
+      if (isNaN(countScale)) {
+        countScale = 1;
+      }
+      break;
+    }
+  }
+  let inputCommand = input.keys.slice(countStr.length);
+  return [inputCommand, countScale];
+};
+
 export default class KeymapperComponent {
   constructor(store) {
     this.store = store;
+  }
+
+  executeOperation(key, state, operation, countScale) {
+    if ('count' in operation) {
+      let countTmp = operation.count;
+      operation.count *= countScale;
+      this.store.dispatch(operationActions.exec(
+        operation, key.repeat, state.setting));
+      operation.count = countTmp;
+    } else {
+      this.store.dispatch(operationActions.exec(
+        operation, key.repeat, state.setting));
+    }
   }
 
   key(key) {
@@ -26,9 +58,10 @@ export default class KeymapperComponent {
     let state = this.store.getState();
     let input = state.input;
     let keymaps = new Map(state.setting.keymaps);
+    let [inputCommand, countScale] = parseKeyInput(input);
 
     let matched = Array.from(keymaps.keys()).filter((mapping) => {
-      return mapStartsWith(mapping, input.keys);
+      return mapStartsWith(mapping, inputCommand);
     });
     if (!state.addon.enabled) {
       // available keymaps are only ADDON_ENABLE and ADDON_TOGGLE_ENABLED if
@@ -43,12 +76,10 @@ export default class KeymapperComponent {
       this.store.dispatch(inputActions.clearKeys());
       return false;
     } else if (matched.length > 1 ||
-      matched.length === 1 && input.keys.length < matched[0].length) {
+      matched.length === 1 && inputCommand.length < matched[0].length) {
       return true;
     }
-    let operation = keymaps.get(matched[0]);
-    this.store.dispatch(operationActions.exec(
-      operation, key.repeat, state.setting));
+    this.executeOperation(key, state, keymaps.get(matched[0]), countScale);
     this.store.dispatch(inputActions.clearKeys());
     return true;
   }


### PR DESCRIPTION
This commit resolves #288
For example, if you type `3J`, then go to the third tab to the left.
This feature is available for tabs.prev, tabs.next, scroll.vertically, 
scroll.horizonally, and scroll.pages because these operation have count property.
If you set count property of j to 5 and type `2j` then scroll distance is
10 times longer than default.