### PR TITLE
 implement :q to close tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ To adjust the search engine default and add/remove search engines, see the [sear
 
 Open a URL or search keywords by search engine in new tab.
 
+#### `:q` command
+
+Close the current tab.
+
 #### `:winopen` command
 
 Open a URL or search keywords by search engine in new window.

--- a/src/background/actions/command.js
+++ b/src/background/actions/command.js
@@ -17,6 +17,12 @@ const tabopenCommand = (url) => {
   return browser.tabs.create({ url: url });
 };
 
+const tabcloseCommand = () => {
+  return browser.tabs.query({ active: true }).then((tabList) => {
+    return browser.tabs.remove(tabList.map(tab => tab.id));
+  });
+};
+
 const winopenCommand = (url) => {
   return browser.windows.create({ url });
 };
@@ -70,6 +76,9 @@ const exec = (line, settings) => {
     return bufferCommand(args);
   case 'set':
     return setCommand(args);
+  case 'q':
+  case 'quit':
+    return tabcloseCommand();
   case '':
     return Promise.resolve();
   }


### PR DESCRIPTION
As per suggestion on issue #260 , add the `:q` (or `:quit`) command to close the current tab.

The behavior is very similar to vim's, so I think it's a great addition.

It's good to allow for a effective option to close tab to users who would like to disable the `d` key (because of accidental usage).