### PR TITLE
add follow link in tab to doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ The default mappings are as follows:
 - <kbd>zd</kbd>: duplicate current tab
 
 ### Navigation
-- <kbd>f</kbd>: start following links in the page
+- <kbd>f</kbd>: start following links in the page in the current tab
+- <kbd>F</kbd>: start following links in the page in new tabs
 - <kbd>H</kbd>: go back in history
 - <kbd>L</kbd>: go forward in history
 - <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: find  prev or next links and open it


### PR DESCRIPTION
Just adds a line in the docs about following links in tabs ( a very useful feature! )