### PR TITLE
QA 0.12

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -40,6 +40,7 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] <kbd>p</kbd>: open clipbord's URL in current tab
 - [ ] <kbd>P</kbd>: open clipbord's URL in new tab
 - [ ] Toggle enabled/disabled of plugin bu <kbd>Shift</kbd>+<kbd>Esc</kbd>
+- [ ] Hide error and info console by <kbd>Esc</kbd>
 
 ### Following links
 
@@ -55,6 +56,7 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] Select link and open it in `<area>` tags, for <kbd>f</kbd> and <kbd>F</kbd>
 - [ ] Configure custom hint character by `:set hintchars=012345678`
 - [ ] Configure custom hint character by settings `"hintchars": "012345678"`
+- [ ] Opened tabs is in child on Tree Style Tab
 
 ### Consoles
 
@@ -187,6 +189,7 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] Search next/prev by <kbd>n</kbd>/<kbd>N</kbd>
 - [ ] Wrap search by <kbd>n</kbd>/<kbd>N</kbd>
 - [ ] Find with last keyword if keyword is empty
+- [ ] Find keyword last used on new tab opened
 
 ## Misc
 

--- a/README.md
+++ b/README.md
@@ -23,26 +23,11 @@ The default mappings are as follows:
 - <kbd>O</kbd>, <kbd>T</kbd>, <kbd>W</kbd>: similar to <kbd>o</kbd>, <kbd>t</kbd>, <kbd>w</kbd>, but that contains current URL
 - <kbd>b</kbd>: Select tabs by URL or title
 
-#### Scrolling
-
-- <kbd>j</kbd>, <kbd>k</kbd>: scroll vertically
-- <kbd>h</kbd>, <kbd>l</kbd>: scroll horizontally
-- <kbd>Ctrl</kbd>+<kbd>U</kbd>, <kbd>Ctrl</kbd>+<kbd>D</kbd>: scroll pages by half of screen
-- <kbd>Ctrl</kbd>+<kbd>B</kbd>, <kbd>Ctrl</kbd>+<kbd>F</kbd>: scroll pages by a screen
-- <kbd>0</kbd>, <kbd>$</kbd>: scroll a page to leftmost/rightmost
-- <kbd>g</kbd><kbd>g</kbd>, <kbd>G</kbd>: scroll to top/bottom
-
 #### Tabs
-- <kbd>d</kbd>: delete current tab
 - <kbd>!</kbd><kbd>d</kbd>: delete pinned tab
 - <kbd>u</kbd>: reopen close tab
-- <kbd>K</kbd>, <kbd>J</kbd>: select prev or next tab
-- <kbd>g0</kbd>, <kbd>g$</kbd>: select first or last tab
-- <kbd>Ctrl</kbd>+<kbd>6</kbd>: select previous selected tab
 - <kbd>r</kbd>: reload current tab
 - <kbd>R</kbd>: reload current tab without cache
-- <kbd>zp</kbd>: toggle pin/unpin current tab
-- <kbd>zd</kbd>: duplicate current tab
 
 ### Navigation
 - <kbd>f</kbd>: start following links in the page
@@ -54,8 +39,6 @@ The default mappings are as follows:
 - <kbd>g</kbd><kbd>i</kbd>: focus first input
 
 #### Misc
-- <kbd>z</kbd><kbd>i</kbd>, <kbd>z</kbd><kbd>o</kbd>: zoom-in/zoom-out
-- <kbd>z</kbd><kbd>z</kbd>: Set default zoom level
 - <kbd>y</kbd>: copy URL in current tab
 - <kbd>p</kbd>: open clipbord's URL in current tab
 - <kbd>P</kbd>: open clipbord's URL in new tab

--- a/README.md
+++ b/README.md
@@ -39,10 +39,14 @@ The default mappings are as follows:
 - <kbd>g</kbd><kbd>i</kbd>: focus first input
 
 #### Misc
+
 - <kbd>y</kbd>: copy URL in current tab
 - <kbd>p</kbd>: open clipbord's URL in current tab
 - <kbd>P</kbd>: open clipbord's URL in new tab
 - <kbd>Shift</kbd>+<kbd>Esc</kbd>: enable or disable the add-on in current tab.
+- <kbd>/</kbd>: start to find a keyword in the page
+- <kbd>n</kbd>: find next keyword in the page
+- <kbd>N</kbd>: find prev keyword in the page
 
 ### Console commands
 

--- a/e2e/contents/tab.test.js
+++ b/e2e/contents/tab.test.js
@@ -52,7 +52,7 @@ describe("tab test", () => {
     });
   })
 
-  it('makes pinned by zd', () => {
+  it('makes pinned by zp', () => {
     let before;
     let targetTab;
     return tabs.create(targetWindow.id, SERVER_URL).then((tab) => {


### PR DESCRIPTION
## Checklist for testing Vim Vixen

### Keybindings in JSON settings

Test operations with default key maps.

#### Scrolling

- [x] Smooth scroll by `:set smoothscroll`
- [x] Non-smooth scroll by `:set nosmoothscroll`
- [x] Configure custom hint character by settings `"smoothscroll": true`, `"smoothscroll": false`

#### Console

The behaviors of the console are tested in [Console section](#consoles).

- [x] <kbd>:</kbd>: open empty console
- [x] <kbd>o</kbd>, <kbd>t</kbd>, <kbd>w</kbd>: open a console with `open`, `tabopen`, `winopen`
- [x] <kbd>O</kbd>, <kbd>T</kbd>, <kbd>W</kbd>: open a console with `open`, `tabopen`, `winopen` and current URL
- [x] <kbd>b</kbd>: open a consolw with `buffer`

#### Tabs

- [x] <kbd>!d</kbd>: delete current tab and pinned tab
- [x] <kbd>u</kbd>: reopen close tab
- [x] <kbd>r</kbd>: reload current tab
- [x] <kbd>R</kbd>: reload current tab without cache

#### Navigation

- [x] <kbd>H</kbd>, <kbd>L</kbd>: go back and forward in history
- [x] <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: Open next/prev link in `<link>` tags.
- [x] <kbd>[</kbd><kbd>[</kbd>, <kbd>]</kbd><kbd>]</kbd>: find prev and next links and open it
- [x] <kbd>g</kbd><kbd>u</kbd>: go to parent directory
- [x] <kbd>g</kbd><kbd>U</kbd>: go to root directory

#### Misc

- [x] <kbd>y</kbd>: yank current URL and show a message
- [x] <kbd>p</kbd>: open clipbord's URL in current tab
- [x] <kbd>P</kbd>: open clipbord's URL in new tab
- [x] Toggle enabled/disabled of plugin bu <kbd>Shift</kbd>+<kbd>Esc</kbd>
- [x] Hide error and info console by <kbd>Esc</kbd>

### Following links

- [x] <kbd>f</kbd>: start following links
- [x] <kbd>F</kbd>: start following links and open in new tab
- [x] open link with target='_blank' in new tab by <kbd>f</kbd>
- [x] open link with target='_blank' in new tab by <kbd>F</kbd>
- [x] Show hints on following on a page containing `<frame>`/`<iframe>`
- [x] Show hints only inside viewport of the frame on following on a page containing `<frame>`/`<iframe>`
- [x] Show hints only inside top window on following on a page containing `<frame>`/`<iframe>`
- [x] Select link and open it in the frame in `<iframe>`/`<frame`> on following by <kbd>f</kbd>
- [x] Select link and open it in new tab in `<iframe>`/`<frame`> on following by <kbd>F</kbd>
- [x] Select link and open it in `<area>` tags, for <kbd>f</kbd> and <kbd>F</kbd>
- [x] Configure custom hint character by `:set hintchars=012345678`
- [x] Configure custom hint character by settings `"hintchars": "012345678"`
- [x] Opened tabs is in child on Tree Style Tab

### Consoles

#### Exec a command

- [x] `<EMPTY>`, `<SP>`: do nothing
<br>

- [x] `open an apple`: search with keywords "an apple" by default search engine (google)
- [x] `open github.com`: open github.com
- [x] `open https://github.com`: open github.com
- [x] `open yahoo an apple`: search with keywords "an apple" by yahoo.com
- [x] `open yahoo`,`open yahoo<SP>`: search with empty keywords; yahoo redirects to top page
- [x] `open`,`open<SP>`: open default search engine
<br>

- [x] `tabopen`: do avobe tests replaced `open` with `tabopen`, and verify the page is opened in new tab
- [x] `winopen`: do avobe tests replaced `open` with `winopen`, and verify the page is opened in new window
<br>

- [x] `buffer`,`buffer<SP>`: do nothing
- [x] `buffer <title>`, `buffer <url>`: select tab which has an title matched with
- [x] `buffer 1`: select leftmost tab
- [x] `buffer 0`, `buffer <a number more than count of tabs>`: shows an error
- [x] select tabs rotationally when more than two tabs are matched

### Completions

#### History and search engines

- [x] `open`: show no completions
- [x] `open<SP>`: show all engines and some history items
- [x] `open g`: complete search engines starts with `g` and matched with keywords `g`
- [x] `open foo bar`: complete history items matched with keywords `foo` and `bar`
- [x] also `tabopen` and `winopen`
- shortening commands such as `o` are not test in this release
- [x] Show competions for `:open`/`:tabopen`/`:buffer` on opning just after closed

#### Buffer command

- [x] `buffer`: show no completions
- [x] `buffer<SP>`: show all opened tabs in completion
- [x] `buffer x`: show tabs which has title and URL matches with `x`

#### Misc

- [x] Select next item by <kbd>Tab</kbd> and previous item by <kbd>Shift</kbd>+<kbd>Tab</kbd>

### Settings

#### JSON Settings

##### Validations

- [x] show error on invalid json
- [x] show error when top-level keys has keys other than `keymaps`, `search`, `blacklist`, and `properties`

###### `"keymaps"` section

- [x] show error on unknown operation name in `"keymaps"`

###### `"search"` section

- validations in `"search"` section are not tested in this release

##### `"blacklist"` section

- [x] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
- [x] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
- [x] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
- [x] `github.com` blocks both `github.com/` and `github.com/a`
- [x] `*.github.com` blocks `gist.github.com/`, and not `github.com`

##### Updating

- [x] changes are updated on textarea blure when no errors
- [x] changes are not updated on textarea blure when errors occurs
- [x] keymap settings are applied to open tabs without reload
- [x] search settings are applied to open tabs without reload

##### Properties

- [x] show errors when invalid property name
- [x] show errors when invalid property type

#### Form Settings

<!-- validation on form settings does not implement in 0.7 -->

##### Search Engines

- [x] able to change default
- [x] able to remove item
- [x] able to add item

##### `"blacklist"` section

- [x] able to add item
- [x] able to remove item
- [x] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
- [x] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
- [x] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
- [x] `github.com` blocks both `github.com/` and `github.com/a`
- [x] `*.github.com` blocks `gist.github.com/`, and not `github.com`

##### Updating

- [x] keymap settings are applied to open tabs without reload
- [x] search settings are applied to open tabs without reload

### Settings source

- [x] show confirmation dialog on switched from json to form
- [x] state is saved on source changed
- [x] on switching form -> json -> form, first and last form setting is equivalent to first one

### For certain sites

- [x] scroll on Hacker News
- [x] able to scroll on Gmail and Slack
- [x] Focus text box on Twitter or Slack, press <kbd>j</kbd>, then <kbd>j</kbd> is typed in the box
- [x] Focus the text box on Twitter or Slack on following mode
- [x] Tha pages is shown in https://pitchify.com/
- [x] Open console in http://www.espncricinfo.com/

## Find mode

- [x] open console with <kbd>/</kbd>
- [x] highlight a word on <kbd>Enter</kbd> pressed in find console
- [x] Search next/prev by <kbd>n</kbd>/<kbd>N</kbd>
- [x] Wrap search by <kbd>n</kbd>/<kbd>N</kbd>
- [x] Find with last keyword if keyword is empty
- [x] Find keyword last used on new tab opened

## Misc

- [x] Work after plugin reload
- [x] Work on `about:blank`
- [x] Able to map `<A-Z>` key.
- [x] Open file menu by <kbd>Alt</kbd>+<kbd>F</kbd> (Other than Mac OS)
