### PR TITLE
Add ctrl-j/p keybindings to select next/previous console completion

### DIFF
--- a/src/console/components/console.js
+++ b/src/console/components/console.js
@@ -77,6 +77,16 @@ export default class ConsoleComponent {
         return this.doEnter(e);
       }
       break;
+    case KeyboardEvent.DOM_VK_J:
+      if (e.ctrlKey) {
+        this.selectNext(e);
+      }
+      break;
+    case KeyboardEvent.DOM_VK_K:
+      if (e.ctrlKey) {
+        this.selectPrev(e);
+      }
+      break;
     case KeyboardEvent.DOM_VK_N:
       if (e.ctrlKey) {
         this.selectNext(e);


### PR DESCRIPTION
This is the corresponding pull request for #365 in case the feature is accepted.

This pull requests adds keybindings that map C-j to select the next entry in the console, and C-k to select the previous entry in the console.