### PR TITLE
change "Plane" to "Plain" in settings page

### DIFF
--- a/src/settings/components/index.jsx
+++ b/src/settings/components/index.jsx
@@ -83,7 +83,7 @@ class SettingsComponent extends Component {
       <Input
         type='textarea'
         name='json'
-        label='Plane JSON'
+        label='Plain JSON'
         spellCheck='false'
         error={this.state.errors.json}
         onChange={this.bindValue.bind(this)}


### PR DESCRIPTION
In the Addons page, I was looking at the title for the JSON settings, and I saw this small typo.
