### PR TITLE
QA 0.13

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -17,7 +17,8 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] <kbd>:</kbd>: open empty console
 - [ ] <kbd>o</kbd>, <kbd>t</kbd>, <kbd>w</kbd>: open a console with `open`, `tabopen`, `winopen`
 - [ ] <kbd>O</kbd>, <kbd>T</kbd>, <kbd>W</kbd>: open a console with `open`, `tabopen`, `winopen` and current URL
-- [ ] <kbd>b</kbd>: open a consolw with `buffer`
+- [ ] <kbd>b</kbd>: open a console with `buffer`
+- [ ] <kbd>a</kbd>: open a console with `addbookmark` and the current page's title
 
 #### Tabs
 
@@ -26,11 +27,16 @@ The behaviors of the console are tested in [Console section](#consoles).
 
 #### Misc
 
+- [ ] <kbd>g</kbd><kbd>f</kbd>: open page source in the new tab.
 - [ ] <kbd>y</kbd>: yank current URL and show a message
-- [ ] <kbd>p</kbd>: open clipbord's URL in current tab
-- [ ] <kbd>P</kbd>: open clipbord's URL in new tab
+- [ ] <kbd>p</kbd>: open clipboard's URL in current tab
+- [ ] <kbd>P</kbd>: open clipboard's URL in new tab
 - [ ] Toggle enabled/disabled of plugin bu <kbd>Shift</kbd>+<kbd>Esc</kbd>
 - [ ] Hide error and info console by <kbd>Esc</kbd>
+- [ ] Vim-Vixen icons changes on <kbd>Shift</kbd>+<kbd>Esc</kbd>
+- [ ] Add-on is enabled and disabled by clicking the indicator on the tool bar.
+- [ ] The indicator changed on selected tab changed (changes add-on enabled)
+- [ ] Notify to users on add-on updated at first time.
 
 ### Following links
 
@@ -40,8 +46,11 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] Select link and open it in the frame in `<iframe>`/`<frame`> on following by <kbd>f</kbd>
 - [ ] Select link and open it in new tab in `<iframe>`/`<frame`> on following by <kbd>F</kbd>
 - [ ] Select link and open it in `<area>` tags, for <kbd>f</kbd> and <kbd>F</kbd>
+- [ ] Open new tab in background by `"background": true`
 - [ ] Configure custom hint character by `:set hintchars=012345678`
-- [ ] Configure custom hint character by settings `"hintchars": "012345678"`
+- [ ] Configure custom hint character by settings `"hintchars": "012345678"` in add-on preferences
+- [ ] Configure adjacent tab by `:set adjacenttab`
+- [ ] Configure adjacent tab by settings `adjacenttab: true` in add-on preferences
 - [ ] Opened tabs is in child on Tree Style Tab
 
 ### Consoles
@@ -59,8 +68,8 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] `open`,`open<SP>`: open default search engine
 <br>
 
-- [ ] `tabopen`: do avobe tests replaced `open` with `tabopen`, and verify the page is opened in new tab
-- [ ] `winopen`: do avobe tests replaced `open` with `winopen`, and verify the page is opened in new window
+- [ ] `tabopen`: do above tests replaced `open` with `tabopen`, and verify the page is opened in new tab
+- [ ] `winopen`: do above tests replaced `open` with `winopen`, and verify the page is opened in new window
 <br>
 
 - [ ] `buffer`,`buffer<SP>`: do nothing
@@ -68,6 +77,19 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] `buffer 1`: select leftmost tab
 - [ ] `buffer 0`, `buffer <a number more than count of tabs>`: shows an error
 - [ ] select tabs rotationally when more than two tabs are matched
+<br>
+
+- [ ] `addbookmark` creates a bookmark
+<br>
+
+- [ ] `q`, `quit`: close current tab
+- [ ] `bdelete`: delete a not-pinned tab matches with keywords
+- [ ] `bdelete`: show errors no-tabs or more than 1 tabs matched
+- [ ] `bdelete`: can not delete pinned tab
+- [ ] `bdelete!`: delete a tab matches with keywords
+- [ ] `bdelete!`: delete a pinned tab matches with keywords
+- [ ] `bdeletes`: delete tabs with matched with keywords excluding pinned
+- [ ] `bdeletes!`: delete tabs with matched with keywords including pinned
 
 ### Completions
 
@@ -77,15 +99,21 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] `open<SP>`: show all engines and some history items
 - [ ] `open g`: complete search engines starts with `g` and matched with keywords `g`
 - [ ] `open foo bar`: complete history items matched with keywords `foo` and `bar`
+- [ ] The completions shows histories, search engines, and bookmarks.
 - [ ] also `tabopen` and `winopen`
 - shortening commands such as `o` are not test in this release
-- [ ] Show competions for `:open`/`:tabopen`/`:buffer` on opning just after closed
+- [ ] Show completions for `:open`/`:tabopen`/`:buffer` on opening just after closed
 
 #### Buffer command
 
 - [ ] `buffer`: show no completions
 - [ ] `buffer<SP>`: show all opened tabs in completion
 - [ ] `buffer x`: show tabs which has title and URL matches with `x`
+
+#### Buffer command
+
+- [ ] `bdelete`, `bdeletes`: show tabs excluding pinned tabs
+- [ ] `bdelete!`, `bdeletes!`: show tabs including pinned tabs
 
 #### Misc
 
@@ -165,7 +193,7 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] able to scroll on Gmail and Slack
 - [ ] Focus text box on Twitter or Slack, press <kbd>j</kbd>, then <kbd>j</kbd> is typed in the box
 - [ ] Focus the text box on Twitter or Slack on following mode
-- [ ] Tha pages is shown in https://pitchify.com/
+- [ ] The pages is shown in https://pitchify.com/
 - [ ] Open console in http://www.espncricinfo.com/
 
 ## Find mode

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The default mappings are as follows:
 - <kbd>o</kbd>, <kbd>t</kbd>, <kbd>w</kbd>: open a page in current tab, new tab, or new window
 - <kbd>O</kbd>, <kbd>T</kbd>, <kbd>W</kbd>: similar to <kbd>o</kbd>, <kbd>t</kbd>, <kbd>w</kbd>, but that contains current URL
 - <kbd>b</kbd>: Select tabs by URL or title
+- <kbd>a</kbd>: add current page to the bookmarks
 
 #### Tabs
 - <kbd>!</kbd><kbd>d</kbd>: delete pinned tab

--- a/src/background/actions/command.js
+++ b/src/background/actions/command.js
@@ -20,7 +20,9 @@ const tabopenCommand = (url) => {
 };
 
 const tabcloseCommand = () => {
-  return browser.tabs.query({ active: true }).then((tabList) => {
+  return browser.tabs.query({
+    active: true, currentWindow: true
+  }).then((tabList) => {
     return browser.tabs.remove(tabList.map(tab => tab.id));
   });
 };

--- a/src/settings/components/form/keymaps-form.jsx
+++ b/src/settings/components/form/keymaps-form.jsx
@@ -51,6 +51,7 @@ const KeyMapFields = [
     ['command.show.winopen?{"alter":false}', 'Open URL in new window'],
     ['command.show.winopen?{"alter":true}', 'Alter URL in new window'],
     ['command.show.buffer', 'Open buffer command'],
+    ['command.show.addbookmark?{"alter":true}', 'Open addbookmark command'],
   ], [
     ['addon.toggle.enabled', 'Enable or disable'],
     ['urls.yank', 'Copy current URL'],
@@ -59,6 +60,7 @@ const KeyMapFields = [
     ['zoom.in', 'Zoom-in'],
     ['zoom.out', 'Zoom-out'],
     ['zoom.neutral', 'Reset zoom level'],
+    ['page.source', 'Open a page source'],
   ]
 ];
 


### PR DESCRIPTION
## Checklist for testing Vim Vixen

### Keybindings in JSON settings

Test operations with default key maps.

#### Scrolling

- [x] Smooth scroll by `:set smoothscroll`
- [x] Non-smooth scroll by `:set nosmoothscroll`
- [x] Configure custom hint character by settings `"smoothscroll": true`, `"smoothscroll": false`

#### Console

The behaviors of the console are tested in [Console section](#consoles).

- [x] <kbd>:</kbd>: open empty console
- [x] <kbd>o</kbd>, <kbd>t</kbd>, <kbd>w</kbd>: open a console with `open`, `tabopen`, `winopen`
- [x] <kbd>O</kbd>, <kbd>T</kbd>, <kbd>W</kbd>: open a console with `open`, `tabopen`, `winopen` and current URL
- [x] <kbd>b</kbd>: open a console with `buffer`
- [x] <kbd>a</kbd>: open a console with `addbookmark` and the current page's title

#### Tabs

- [x] <kbd>r</kbd>: reload current tab
- [x] <kbd>R</kbd>: reload current tab without cache

#### Misc

- [x] <kbd>g</kbd><kbd>f</kbd>: open page source in the new tab.
- [x] <kbd>y</kbd>: yank current URL and show a message
- [x] <kbd>p</kbd>: open clipboard's URL in current tab
- [x] <kbd>P</kbd>: open clipboard's URL in new tab
- [x] Toggle enabled/disabled of plugin bu <kbd>Shift</kbd>+<kbd>Esc</kbd>
- [x] Hide error and info console by <kbd>Esc</kbd>
- [x] Vim-Vixen icons changes on <kbd>Shift</kbd>+<kbd>Esc</kbd>
- [x] Add-on is enabled and disabled by clicking the indicator on the tool bar.
- [x] The indicator changed on selected tab changed (changes add-on enabled)
- [x] Notify to users on add-on updated at first time.

### Following links

- [x] Show hints on following on a page containing `<frame>`/`<iframe>`
- [x] Show hints only inside viewport of the frame on following on a page containing `<frame>`/`<iframe>`
- [x] Show hints only inside top window on following on a page containing `<frame>`/`<iframe>`
- [x] Select link and open it in the frame in `<iframe>`/`<frame`> on following by <kbd>f</kbd>
- [x] Select link and open it in new tab in `<iframe>`/`<frame`> on following by <kbd>F</kbd>
- [x] Select link and open it in `<area>` tags, for <kbd>f</kbd> and <kbd>F</kbd>
- [x] Open new tab in background by `"background": true`
- [x] Configure custom hint character by `:set hintchars=012345678`
- [x] Configure custom hint character by settings `"hintchars": "012345678"` in add-on preferences
- [x] Configure adjacent tab by `:set adjacenttab`
- [x] Configure adjacent tab by settings `adjacenttab: true` in add-on preferences
- [x] Opened tabs is in child on Tree Style Tab

### Consoles

#### Exec a command

- [x] `<EMPTY>`, `<SP>`: do nothing
<br>

- [x] `open an apple`: search with keywords "an apple" by default search engine (google)
- [x] `open github.com`: open github.com
- [x] `open https://github.com`: open github.com
- [x] `open yahoo an apple`: search with keywords "an apple" by yahoo.com
- [x] `open yahoo`,`open yahoo<SP>`: search with empty keywords; yahoo redirects to top page
- [x] `open`,`open<SP>`: open default search engine
<br>

- [x] `tabopen`: do above tests replaced `open` with `tabopen`, and verify the page is opened in new tab
- [x] `winopen`: do above tests replaced `open` with `winopen`, and verify the page is opened in new window
<br>

- [x] `buffer`,`buffer<SP>`: do nothing
- [x] `buffer <title>`, `buffer <url>`: select tab which has an title matched with
- [x] `buffer 1`: select leftmost tab
- [x] `buffer 0`, `buffer <a number more than count of tabs>`: shows an error
- [x] select tabs rotationally when more than two tabs are matched
<br>

- [x] `addbookmark` creates a bookmark
<br>

- [x] `q`, `quit`: close current tab
- [x] `bdelete`: delete a not-pinned tab matches with keywords
- [x] `bdelete`: show errors no-tabs or more than 1 tabs matched
- [x] `bdelete`: can not delete pinned tab
- [x] `bdelete!`: delete a tab matches with keywords
- [x] `bdelete!`: delete a pinned tab matches with keywords
- [x] `bdeletes`: delete tabs with matched with keywords excluding pinned
- [x] `bdeletes!`: delete tabs with matched with keywords including pinned

### Completions

#### History and search engines

- [x] `open`: show no completions
- [x] `open<SP>`: show all engines and some history items
- [x] `open g`: complete search engines starts with `g` and matched with keywords `g`
- [x] `open foo bar`: complete history items matched with keywords `foo` and `bar`
- [x] The completions shows histories, search engines, and bookmarks.
- [x] also `tabopen` and `winopen`
- shortening commands such as `o` are not test in this release
- [x] Show completions for `:open`/`:tabopen`/`:buffer` on opening just after closed

#### Buffer command

- [x] `buffer`: show no completions
- [x] `buffer<SP>`: show all opened tabs in completion
- [x] `buffer x`: show tabs which has title and URL matches with `x`

#### Buffer command

- [x] `bdelete`, `bdeletes`: show tabs excluding pinned tabs
- [x] `bdelete!`, `bdeletes!`: show tabs including pinned tabs

#### Misc

- [x] Select next item by <kbd>Tab</kbd> and previous item by <kbd>Shift</kbd>+<kbd>Tab</kbd>

### Settings

#### JSON Settings

##### Validations

- [x] show error on invalid json
- [x] show error when top-level keys has keys other than `keymaps`, `search`, `blacklist`, and `properties`

###### `"keymaps"` section

- [x] show error on unknown operation name in `"keymaps"`

###### `"search"` section

- validations in `"search"` section are not tested in this release

##### `"blacklist"` section

- [x] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
- [x] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
- [x] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
- [x] `github.com` blocks both `github.com/` and `github.com/a`
- [x] `*.github.com` blocks `gist.github.com/`, and not `github.com`

##### Updating

- [x] changes are updated on textarea blure when no errors
- [x] changes are not updated on textarea blure when errors occurs
- [x] keymap settings are applied to open tabs without reload
- [x] search settings are applied to open tabs without reload

##### Properties

- [x] show errors when invalid property name
- [x] show errors when invalid property type

#### Form Settings

<!-- validation on form settings does not implement in 0.7 -->

##### Search Engines

- [x] able to change default
- [x] able to remove item
- [x] able to add item

##### `"blacklist"` section

- [x] able to add item
- [x] able to remove item
- [x] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
- [x] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
- [x] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
- [x] `github.com` blocks both `github.com/` and `github.com/a`
- [x] `*.github.com` blocks `gist.github.com/`, and not `github.com`

##### Updating

- [x] keymap settings are applied to open tabs without reload
- [x] search settings are applied to open tabs without reload

### Settings source

- [x] show confirmation dialog on switched from json to form
- [x] state is saved on source changed
- [x] on switching form -> json -> form, first and last form setting is equivalent to first one

### For certain sites

- [x] scroll on Hacker News
- [x] able to scroll on Gmail and Slack
- [x] Focus text box on Twitter or Slack, press <kbd>j</kbd>, then <kbd>j</kbd> is typed in the box
- [x] Focus the text box on Twitter or Slack on following mode
- [x] The pages is shown in https://pitchify.com/
- [x] Open console in http://www.espncricinfo.com/

## Find mode

- [x] open console with <kbd>/</kbd>
- [x] highlight a word on <kbd>Enter</kbd> pressed in find console
- [x] Search next/prev by <kbd>n</kbd>/<kbd>N</kbd>
- [x] Wrap search by <kbd>n</kbd>/<kbd>N</kbd>
- [x] Find with last keyword if keyword is empty
- [x] Find keyword last used on new tab opened

## Misc

- [x] Work after plugin reload
- [x] Work on `about:blank`
- [x] Able to map `<A-Z>` key.
- [x] Open file menu by <kbd>Alt</kbd>+<kbd>F</kbd> (Other than Mac OS)
