### PR TITLE
Ignore case tab filtering

### DIFF
--- a/src/background/shared/completions/tabs.js
+++ b/src/background/shared/completions/tabs.js
@@ -1,12 +1,8 @@
+import * as tabs from '../tabs';
+
 const getCompletions = (keyword, excludePinned) => {
-  return browser.tabs.query({ currentWindow: true }).then((tabs) => {
-    let matched = tabs.filter((t) => {
-      return t.url.includes(keyword) || t.title && t.title.includes(keyword);
-    }).filter((t) => {
-      return !(excludePinned && t.pinned);
-    });
-    return matched;
-  });
+  return tabs.queryByKeyword(keyword, excludePinned);
 };
+
 
 export { getCompletions };

--- a/src/background/shared/tabs.js
+++ b/src/background/shared/tabs.js
@@ -87,7 +87,7 @@ const selectAt = (index) => {
 const selectByKeyword = (current, keyword) => {
   return browser.tabs.query({ currentWindow: true }).then((tabs) => {
     let matched = tabs.filter((t) => {
-      return t.url.includes(keyword) || t.title.includes(keyword);
+      return t.url.includes(keyword) || t.title && t.title.includes(keyword);
     });
 
     if (matched.length === 0) {

--- a/src/background/shared/tabs.js
+++ b/src/background/shared/tabs.js
@@ -15,7 +15,8 @@ const closeTabForce = (id) => {
 const queryByKeyword = (keyword, excludePinned = false) => {
   return browser.tabs.query({ currentWindow: true }).then((tabs) => {
     return tabs.filter((t) => {
-      return t.url.includes(keyword) || t.title && t.title.includes(keyword);
+      return t.url.toLowerCase().includes(keyword.toLowerCase()) ||
+        t.title && t.title.toLowerCase().includes(keyword.toLowerCase());
     }).filter((t) => {
       return !(excludePinned && t.pinned);
     });


### PR DESCRIPTION
- Filter tabs by ignoring cases (#125 proposes a smart case).  That is a default behavior of the location bar.
- Fix a bug that tab selections shows an error: "a.title is undefined" (close #352)