### PR TITLE
QA 0.15

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -27,7 +27,6 @@ The behaviors of the console are tested in [Console section](#consoles).
 
 #### Misc
 
-- [ ] <kbd>g</kbd><kbd>f</kbd>: open page source in the new tab.
 - [ ] <kbd>y</kbd>: yank current URL and show a message
 - [ ] <kbd>p</kbd>: open clipboard's URL in current tab
 - [ ] <kbd>P</kbd>: open clipboard's URL in new tab

--- a/QA.md
+++ b/QA.md
@@ -118,6 +118,7 @@ The behaviors of the console are tested in [Console section](#consoles).
 #### Misc
 
 - [ ] Select next item by <kbd>Tab</kbd> and previous item by <kbd>Shift</kbd>+<kbd>Tab</kbd>
+- [ ] Reopen tab on *only current window* by <kbd>u</kbd>
 
 ### Settings
 

--- a/e2e/contents/navigate.test.js
+++ b/e2e/contents/navigate.test.js
@@ -20,7 +20,7 @@ describe("navigate test", () => {
     let tab = await tabs.create(targetWindow.id, CLIENT_URL + '/a/b/c');
     await keys.press(tab.id, 'g');
     await keys.press(tab.id, 'u');
-    await new Promise(resolve => { setTimeout(() => resolve(), 10) });
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
     tab = await tabs.get(tab.id);
     expect(tab.url).to.be.equal(CLIENT_URL + '/a/b/');
@@ -38,7 +38,7 @@ describe("navigate test", () => {
     let tab = await tabs.create(targetWindow.id, CLIENT_URL + '/a/b/c');
     await keys.press(tab.id, 'g');
     await keys.press(tab.id, 'U', { shiftKey: true });
-    await new Promise(resolve => { setTimeout(() => resolve(), 10) });
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
     tab = await tabs.get(tab.id);
     expect(tab.url).to.be.equal(CLIENT_URL + '/');
@@ -49,11 +49,11 @@ describe("navigate test", () => {
     await keys.press(tab.id, 'g');
     await keys.press(tab.id, 'u');
     await keys.press(tab.id, 'H', { shiftKey: true });
-    await new Promise(resolve => { setTimeout(() => resolve(), 10) });
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
     tab = await tabs.get(tab.id);
     expect(tab.url, 'go back in history').to.be.equal(CLIENT_URL + '/#navigate');
-    await new Promise(resolve => { setTimeout(() => resolve(), 10) });
+    await new Promise((resolve) => setTimeout(resolve, 10));
     await keys.press(tab.id, 'L', { shiftKey: true });
 
     tab = await tabs.get(tab.id);
@@ -64,7 +64,7 @@ describe("navigate test", () => {
     let tab = await tabs.create(targetWindow.id, CLIENT_URL + '/a-pagenation?page=10');
     await keys.press(tab.id, '[');
     await keys.press(tab.id, '[');
-    await new Promise(resolve => { setTimeout(() => resolve(), 10) });
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
     tab = await tabs.get(tab.id);
     expect(tab.url).to.be.equal(CLIENT_URL + '/a-pagenation?page=9');
@@ -74,7 +74,7 @@ describe("navigate test", () => {
     let tab = await tabs.create(targetWindow.id, CLIENT_URL + '/a-pagenation?page=10');
     await keys.press(tab.id, ']');
     await keys.press(tab.id, ']');
-    await new Promise(resolve => { setTimeout(() => resolve(), 10) });
+    await new Promise((resolve) => setTimeout(resolve, 100));
 
     tab = await tabs.get(tab.id);
     expect(tab.url).to.be.equal(CLIENT_URL + '/a-pagenation?page=11');
@@ -84,7 +84,7 @@ describe("navigate test", () => {
     let tab = await tabs.create(targetWindow.id, CLIENT_URL + '/link-pagenation?page=10');
     await keys.press(tab.id, '[');
     await keys.press(tab.id, '[');
-    await new Promise(resolve => { setTimeout(() => resolve(), 10) });
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
     tab = await tabs.get(tab.id);
     expect(tab.url).to.be.equal(CLIENT_URL + '/link-pagenation?page=9');
@@ -94,7 +94,7 @@ describe("navigate test", () => {
     let tab = await tabs.create(targetWindow.id, CLIENT_URL + '/link-pagenation?page=10');
     await keys.press(tab.id, ']');
     await keys.press(tab.id, ']');
-    await new Promise(resolve => { setTimeout(() => resolve(), 10) });
+    await new Promise((resolve) => setTimeout(resolve, 10));
 
     tab = await tabs.get(tab.id);
     expect(tab.url).to.be.equal(CLIENT_URL + '/link-pagenation?page=11');

--- a/e2e/contents/tab.test.js
+++ b/e2e/contents/tab.test.js
@@ -174,7 +174,7 @@ describe("tab test", () => {
     }).then(() => {
       return keys.press(target.id, 'f');
     }).then(() => {
-      return new Promise((resolve) => setTimeout(resolve, 300));
+      return new Promise((resolve) => setTimeout(resolve, 500));
     }).then(() => {
       return windows.get(targetWindow.id);
     }).then((win) => {

--- a/e2e/contents/tab.test.js
+++ b/e2e/contents/tab.test.js
@@ -163,4 +163,22 @@ describe("tab test", () => {
     let win = await windows.get(targetWindow.id);
     expect(win.tabs).to.have.lengthOf(1);
   });
+
+  it('opens view-source by gf', () => {
+    let target;
+    return Promise.resolve().then(() => {
+      return windows.get(targetWindow.id);
+    }).then((win) => {
+      target = win.tabs[0];
+      return keys.press(target.id, 'g');
+    }).then(() => {
+      return keys.press(target.id, 'f');
+    }).then(() => {
+      return new Promise((resolve) => setTimeout(resolve, 300));
+    }).then(() => {
+      return windows.get(targetWindow.id);
+    }).then((win) => {
+      expect(win.tabs.map((t) => t.url)).to.include.members([CLIENT_URL + '/', 'view-source:' + CLIENT_URL + '/']);
+    });
+  });
 });

--- a/e2e/contents/tab.test.js
+++ b/e2e/contents/tab.test.js
@@ -139,7 +139,7 @@ describe("tab test", () => {
     expect(win.tabs).to.have.lengthOf(1);
 
     await keys.press(win.tabs[0].id, 'u');
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise(resolve => setTimeout(resolve, 100));
 
     win = await windows.get(targetWindow.id);
     expect(win.tabs).to.have.lengthOf(2);
@@ -164,21 +164,15 @@ describe("tab test", () => {
     expect(win.tabs).to.have.lengthOf(1);
   });
 
-  it('opens view-source by gf', () => {
-    let target;
-    return Promise.resolve().then(() => {
-      return windows.get(targetWindow.id);
-    }).then((win) => {
-      target = win.tabs[0];
-      return keys.press(target.id, 'g');
-    }).then(() => {
-      return keys.press(target.id, 'f');
-    }).then(() => {
-      return new Promise((resolve) => setTimeout(resolve, 500));
-    }).then(() => {
-      return windows.get(targetWindow.id);
-    }).then((win) => {
-      expect(win.tabs.map((t) => t.url)).to.include.members([CLIENT_URL + '/', 'view-source:' + CLIENT_URL + '/']);
-    });
+  it('opens view-source by gf', async () => {
+    let win = await windows.get(targetWindow.id);
+    let tab = win.tabs[0];
+    await keys.press(tab.id, 'g');
+    await keys.press(tab.id, 'f');
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    win = await windows.get(targetWindow.id);
+    let urls = win.tabs.map((t) => t.url)
+    expect(urls).to.include.members([CLIENT_URL + '/', 'view-source:' + CLIENT_URL + '/']);
   });
 });

--- a/src/background/shared/tabs.js
+++ b/src/background/shared/tabs.js
@@ -22,7 +22,7 @@ const queryByKeyword = async(keyword, excludePinned = false) => {
 };
 
 const closeTabByKeywords = async(keyword) => {
-  let tabs = await queryByKeyword(keyword, false);
+  let tabs = await queryByKeyword(keyword, true);
   if (tabs.length === 0) {
     throw new Error('No matching buffer for ' + keyword);
   } else if (tabs.length > 1) {
@@ -32,7 +32,7 @@ const closeTabByKeywords = async(keyword) => {
 };
 
 const closeTabByKeywordsForce = async(keyword) => {
-  let tabs = await queryByKeyword(keyword, true);
+  let tabs = await queryByKeyword(keyword, false);
   if (tabs.length === 0) {
     throw new Error('No matching buffer for ' + keyword);
   } else if (tabs.length > 1) {


### PR DESCRIPTION
## Checklist for testing Vim Vixen

### Keybindings in JSON settings

Test operations with default key maps.

#### Scrolling

- [x] Smooth scroll by `:set smoothscroll`
- [x] Non-smooth scroll by `:set nosmoothscroll`
- [x] Configure custom hint character by settings `"smoothscroll": true`, `"smoothscroll": false`

#### Console

The behaviors of the console are tested in [Console section](#consoles).

- [x] <kbd>:</kbd>: open empty console
- [x] <kbd>o</kbd>, <kbd>t</kbd>, <kbd>w</kbd>: open a console with `open`, `tabopen`, `winopen`
- [x] <kbd>O</kbd>, <kbd>T</kbd>, <kbd>W</kbd>: open a console with `open`, `tabopen`, `winopen` and current URL
- [x] <kbd>b</kbd>: open a console with `buffer`
- [x] <kbd>a</kbd>: open a console with `addbookmark` and the current page's title

#### Tabs

- [x] <kbd>r</kbd>: reload current tab
- [x] <kbd>R</kbd>: reload current tab without cache

#### Misc

- [x] <kbd>g</kbd><kbd>f</kbd>: open page source in the new tab.
- [x] <kbd>y</kbd>: yank current URL and show a message
- [x] <kbd>p</kbd>: open clipboard's URL in current tab
- [x] <kbd>P</kbd>: open clipboard's URL in new tab
- [x] Toggle enabled/disabled of plugin bu <kbd>Shift</kbd>+<kbd>Esc</kbd>
- [x] Hide error and info console by <kbd>Esc</kbd>
- [x] Vim-Vixen icons changes on <kbd>Shift</kbd>+<kbd>Esc</kbd>
- [x] Add-on is enabled and disabled by clicking the indicator on the tool bar.
- [x] The indicator changed on selected tab changed (changes add-on enabled)
- [x] Notify to users on add-on updated at first time.

### Following links

- [x] Show hints on following on a page containing `<frame>`/`<iframe>`
- [x] Show hints only inside viewport of the frame on following on a page containing `<frame>`/`<iframe>`
- [x] Show hints only inside top window on following on a page containing `<frame>`/`<iframe>`
- [x] Select link and open it in the frame in `<iframe>`/`<frame`> on following by <kbd>f</kbd>
- [x] Select link and open it in new tab in `<iframe>`/`<frame`> on following by <kbd>F</kbd>
- [x] Select link and open it in `<area>` tags, for <kbd>f</kbd> and <kbd>F</kbd>
- [x] Open new tab in background by `"background": true`
- [x] Configure custom hint character by `:set hintchars=012345678`
- [x] Configure custom hint character by settings `"hintchars": "012345678"` in add-on preferences
- [x] Configure adjacent tab by `:set adjacenttab`
- [x] Configure adjacent tab by settings `adjacenttab: true` in add-on preferences
- [x] Opened tabs is in child on Tree Style Tab

### Consoles

#### Exec a command

- [x] `<EMPTY>`, `<SP>`: do nothing
<br>

- [x] `open an apple`: search with keywords "an apple" by default search engine (google)
- [x] `open github.com`: open github.com
- [x] `open https://github.com`: open github.com
- [x] `open yahoo an apple`: search with keywords "an apple" by yahoo.com
- [x] `open yahoo`,`open yahoo<SP>`: search with empty keywords; yahoo redirects to top page
- [x] `open`,`open<SP>`: open default search engine
<br>

- [x] `tabopen`: do above tests replaced `open` with `tabopen`, and verify the page is opened in new tab
- [x] `winopen`: do above tests replaced `open` with `winopen`, and verify the page is opened in new window
<br>

- [x] `buffer`,`buffer<SP>`: do nothing
- [x] `buffer <title>`, `buffer <url>`: select tab which has an title matched with
- [x] `buffer 1`: select leftmost tab
- [x] `buffer 0`, `buffer <a number more than count of tabs>`: shows an error
- [x] select tabs rotationally when more than two tabs are matched
<br>

- [x] `addbookmark` creates a bookmark
<br>

- [x] `q`, `quit`: close current tab
- [x] `bdelete`: delete a not-pinned tab matches with keywords
- [x] `bdelete`: show errors no-tabs or more than 1 tabs matched
- [x] `bdelete`: can not delete pinned tab
- [x] `bdelete!`: delete a tab matches with keywords
- [x] `bdelete!`: delete a pinned tab matches with keywords
- [x] `bdeletes`: delete tabs with matched with keywords excluding pinned
- [x] `bdeletes!`: delete tabs with matched with keywords including pinned

### Completions

#### History and search engines

- [x] `open`: show no completions
- [x] `open<SP>`: show all engines and some history items
- [x] `open g`: complete search engines starts with `g` and matched with keywords `g`
- [x] `open foo bar`: complete history items matched with keywords `foo` and `bar`
- [x] The completions shows histories, search engines, and bookmarks.
- [x] also `tabopen` and `winopen`
- shortening commands such as `o` are not test in this release
- [x] Show completions for `:open`/`:tabopen`/`:buffer` on opening just after closed

#### Buffer command

- [x] `buffer`: show no completions
- [x] `buffer<SP>`: show all opened tabs in completion
- [x] `buffer x`: show tabs which has title and URL matches with `x`

#### Buffer command

- [x] `bdelete`, `bdeletes`: show tabs excluding pinned tabs
- [x] `bdelete!`, `bdeletes!`: show tabs including pinned tabs

#### Misc

- [x] Select next item by <kbd>Tab</kbd> and previous item by <kbd>Shift</kbd>+<kbd>Tab</kbd>
- [x] Reopen tab on *only current window* by <kbd>u</kbd>

### Settings

#### JSON Settings

##### Validations

- [x] show error on invalid json
- [x] show error when top-level keys has keys other than `keymaps`, `search`, `blacklist`, and `properties`

###### `"keymaps"` section

- [x] show error on unknown operation name in `"keymaps"`

###### `"search"` section

- validations in `"search"` section are not tested in this release

##### `"blacklist"` section

- [x] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
- [x] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
- [x] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
- [x] `github.com` blocks both `github.com/` and `github.com/a`
- [x] `*.github.com` blocks `gist.github.com/`, and not `github.com`

##### Updating

- [x] changes are updated on textarea blure when no errors
- [x] changes are not updated on textarea blure when errors occurs
- [x] keymap settings are applied to open tabs without reload
- [x] search settings are applied to open tabs without reload

##### Properties

- [x] show errors when invalid property name
- [x] show errors when invalid property type

#### Form Settings

<!-- validation on form settings does not implement in 0.7 -->

##### Search Engines

- [x] able to change default
- [x] able to remove item
- [x] able to add item

##### `"blacklist"` section

- [x] able to add item
- [x] able to remove item
- [x] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
- [x] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
- [x] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
- [x] `github.com` blocks both `github.com/` and `github.com/a`
- [x] `*.github.com` blocks `gist.github.com/`, and not `github.com`

##### Updating

- [x] keymap settings are applied to open tabs without reload
- [x] search settings are applied to open tabs without reload

### Settings source

- [x] show confirmation dialog on switched from json to form
- [x] state is saved on source changed
- [x] on switching form -> json -> form, first and last form setting is equivalent to first one

### For certain sites

- [x] scroll on Hacker News
- [x] able to scroll on Gmail and Slack
- [x] Focus text box on Twitter or Slack, press <kbd>j</kbd>, then <kbd>j</kbd> is typed in the box
- [x] Focus the text box on Twitter or Slack on following mode
- [x] The pages is shown in https://pitchify.com/
- [x] Open console in http://www.espncricinfo.com/

## Find mode

- [x] open console with <kbd>/</kbd>
- [x] highlight a word on <kbd>Enter</kbd> pressed in find console
- [x] Search next/prev by <kbd>n</kbd>/<kbd>N</kbd>
- [x] Wrap search by <kbd>n</kbd>/<kbd>N</kbd>
- [x] Find with last keyword if keyword is empty
- [x] Find keyword last used on new tab opened

## Misc

- [x] Work after plugin reload
- [x] Work on `about:blank`
- [x] Able to map `<A-Z>` key.
- [x] Open file menu by <kbd>Alt</kbd>+<kbd>F</kbd> (Other than Mac OS)
