### PR TITLE
Allow following <summary> elements

### DIFF
--- a/src/content/components/common/follow.js
+++ b/src/content/components/common/follow.js
@@ -5,7 +5,7 @@ import * as dom from 'shared/utils/dom';
 const TARGET_SELECTOR = [
   'a', 'button', 'input', 'textarea', 'area',
   '[contenteditable=true]', '[contenteditable=""]', '[tabindex]',
-  '[role="button"]'
+  '[role="button"]', 'summary'
 ].join(',');
 
 
@@ -155,6 +155,7 @@ export default class Follow {
     case 'textarea':
       return element.focus();
     case 'button':
+    case 'summary':
       return element.click();
     default:
       if (dom.isContentEditable(element)) {

--- a/test/content/components/common/follow.html
+++ b/test/content/components/common/follow.html
@@ -8,5 +8,10 @@
     <div id='editable_div_1' contenteditable>link</div>
     <div id='editable_div_2' contenteditable='true'>link</div>
     <div id='x' contenteditable='false'>link</div>
+    <details>
+      <summary id='summary_1'>summary link</summary>
+      Some details
+      <a href='#'>not visible</a>
+    </details>
   </body>
 </html>

--- a/test/content/components/common/follow.test.js
+++ b/test/content/components/common/follow.test.js
@@ -11,10 +11,15 @@ describe('FollowComponent', () => {
         window,
         { width: window.innerWidth, height: window.innerHeight },
         { x: 0, y: 0 });
-      expect(targets).to.have.lengthOf(3);
+      expect(targets).to.have.lengthOf(4);
 
       let ids = Array.prototype.map.call(targets, (e) => e.id);
-      expect(ids).to.include.members(['visible_a', 'editable_div_1', 'editable_div_2']);
+      expect(ids).to.include.members([
+        'visible_a',
+        'editable_div_1',
+        'editable_div_2',
+        'summary_1',
+      ]);
     });
   });
 });


### PR DESCRIPTION
This makes it possible to follow `<summary>` elements inside HTML `<detail>` elements, in order to expand the details.

A good example usecase for you is to view the complete diff right here on Github. The "Review" dropdown button is actually a `<summary>` element and cannot be clicked using <kbd>f</kbd> for that reason.