### PR TITLE
Add complete property

### DIFF
--- a/src/background/usecases/completions.js
+++ b/src/background/usecases/completions.js
@@ -36,18 +36,29 @@ export default class CompletionsInteractor {
   }
 
   async queryOpen(name, keywords) {
+    let settings = await this.settingRepository.get();
     let groups = [];
-    let engines = await this.querySearchEngineItems(name, keywords);
-    if (engines.length > 0) {
-      groups.push(new CompletionGroup('Search Engines', engines));
-    }
-    let histories = await this.queryHistoryItems(name, keywords);
-    if (histories.length > 0) {
-      groups.push(new CompletionGroup('History', histories));
-    }
-    let bookmarks = await this.queryBookmarkItems(name, keywords);
-    if (bookmarks.length > 0) {
-      groups.push(new CompletionGroup('Bookmarks', bookmarks));
+
+    for (let c of settings.properties.complete) {
+      if (c === 's') {
+        // eslint-disable-next-line no-await-in-loop
+        let engines = await this.querySearchEngineItems(name, keywords);
+        if (engines.length > 0) {
+          groups.push(new CompletionGroup('Search Engines', engines));
+        }
+      } else if (c === 'h') {
+        // eslint-disable-next-line no-await-in-loop
+        let histories = await this.queryHistoryItems(name, keywords);
+        if (histories.length > 0) {
+          groups.push(new CompletionGroup('History', histories));
+        }
+      } else if (c === 'b') {
+        // eslint-disable-next-line no-await-in-loop
+        let bookmarks = await this.queryBookmarkItems(name, keywords);
+        if (bookmarks.length > 0) {
+          groups.push(new CompletionGroup('Bookmarks', bookmarks));
+        }
+      }
     }
     return new Completions(groups);
   }

--- a/src/shared/settings/default.js
+++ b/src/shared/settings/default.js
@@ -72,7 +72,8 @@ export default {
   "properties": {
     "hintchars": "abcdefghijklmnopqrstuvwxyz",
     "smoothscroll": false,
-    "adjacenttab": true
+    "adjacenttab": true,
+    "complete": "sbh"
   },
   "blacklist": [
   ]

--- a/src/shared/settings/properties.js
+++ b/src/shared/settings/properties.js
@@ -6,6 +6,7 @@ const types = {
   hintchars: 'string',
   smoothscroll: 'boolean',
   adjacenttab: 'boolean',
+  complete: 'string',
 };
 
 // describe default values of a property
@@ -13,12 +14,14 @@ const defaults = {
   hintchars: 'abcdefghijklmnopqrstuvwxyz',
   smoothscroll: false,
   adjacenttab: true,
+  complete: 'sbn',
 };
 
 const docs = {
   hintchars: 'hint characters on follow mode',
   smoothscroll: 'smooth scroll',
   adjacenttab: 'open adjacent tabs',
+  complete: 'which are completed at the open page',
 };
 
 export { types, defaults, docs };


### PR DESCRIPTION
close #68 

Add `complete` property to control suggestions on `:open` command.  The property is a char set including the following characters: 

- `s`: search engines
- `h`: history
- `b`: bookmarks

For example, user set `complete` property by the following command

```console
:set complete=sh
```

the completion items on `:open` command are shown only search engines and the history items.