### PR TITLE
correct INPUT_KEY_PRESS action type name

### DIFF
--- a/src/content/actions/index.js
+++ b/src/content/actions/index.js
@@ -6,7 +6,7 @@ export default {
   SETTING_SET: 'setting.set',
 
   // User input
-  INPUT_KEY_PRESS: 'input.key,press',
+  INPUT_KEY_PRESS: 'input.key.press',
   INPUT_CLEAR_KEYS: 'input.clear.keys',
 
   // Completion


### PR DESCRIPTION
change `INPUT_KEY_PRESS` action type name form `input.key,press` to `input.key.press` for consistent names.