### PR TITLE
QA 0.19

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -4,12 +4,6 @@
 
 Test operations with default key maps.
 
-#### Scrolling
-
-- [ ] Smooth scroll by `:set smoothscroll`
-- [ ] Non-smooth scroll by `:set nosmoothscroll`
-- [ ] Configure custom hint character by settings `"smoothscroll": true`, `"smoothscroll": false`
-
 #### Console
 
 The behaviors of the console are tested in [Console section](#consoles).
@@ -48,9 +42,6 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] Select link and open it in new tab in `<iframe>`/`<frame`> on following by <kbd>F</kbd>
 - [ ] Select link and open it in `<area>` tags, for <kbd>f</kbd> and <kbd>F</kbd>
 - [ ] Open new tab in background by `"background": true`
-- [ ] Configure custom hint character by `:set hintchars=012345678`
-- [ ] Configure custom hint character by settings `"hintchars": "012345678"` in add-on preferences
-- [ ] Opened tabs is in child on Tree Style Tab
 
 ### Consoles
 
@@ -121,6 +112,20 @@ The behaviors of the console are tested in [Console section](#consoles).
 
 - [ ] Select next item by <kbd>Tab</kbd> and previous item by <kbd>Shift</kbd>+<kbd>Tab</kbd>
 - [ ] Reopen tab on *only current window* by <kbd>u</kbd>
+
+### Properties
+
+- [ ] Configure custom hint character by `:set hintchars=012345678`
+- [ ] Configure custom hint character by settings `"hintchars": "012345678"` in add-on preferences
+- [ ] Opened tabs is in child on Tree Style Tab
+
+- [ ] Smooth scroll by `:set smoothscroll`
+- [ ] Non-smooth scroll by `:set nosmoothscroll`
+- [ ] Configure smooth scroll by settings `"smoothscroll": true`, `"smoothscroll": false`
+
+- [ ] Show search engine, bookmark and history items in order by `:set complete=sbh`
+- [ ] Show bookmark, search engine, and search engine items in order by `:set complete=bss`
+- [ ] Configure completion items by setting `"smoothscroll": "sbh"`, `"smoothscroll": "bss"`
 
 ### Settings
 

--- a/QA.md
+++ b/QA.md
@@ -125,7 +125,7 @@ The behaviors of the console are tested in [Console section](#consoles).
 
 - [ ] Show search engine, bookmark and history items in order by `:set complete=sbh`
 - [ ] Show bookmark, search engine, and search engine items in order by `:set complete=bss`
-- [ ] Configure completion items by setting `"smoothscroll": "sbh"`, `"smoothscroll": "bss"`
+- [ ] Configure completion items by setting `"complete": "sbh"`, `"complete": "bss"`
 
 ### Settings
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ See [console commands](#console-commands) section for more detailed description
 - <kbd>G</kbd>: scroll to bottom of a page
 - <kbd>0</kbd>: scroll to the leftmost part of a page
 - <kbd>$</kbd>: scroll to the rightmost part of a page
+- <kbd>m</kbd>: set a mark from current position
+- <kbd>'</kbd>: jump to position by the mark
+
+Lowercase alphabet mark (`[a-z]`) stores position on the current tab. Upper alphabet and numeric mark (`[A-Z0-9]`) stores position and tab.
 
 #### Zoom
 
@@ -217,6 +221,19 @@ Set hint characters
 
 ```
 :set hintchars=0123456789
+```
+
+#### `complete` property
+
+Set completion items on `open`, `tabopen` `winopen` commands.
+The allowed value is character sequence of `s`, `b`, or `n`.
+Each character presents as following:
+- `s`: search engines
+- `b`: bookmark items
+- `h`: history items.
+
+```
+:set complete=sbn
 ```
 
 ### Search engines

--- a/e2e/ambassador/src/background/index.js
+++ b/e2e/ambassador/src/background/index.js
@@ -1,6 +1,6 @@
 import {
   WINDOWS_CREATE, WINDOWS_REMOVE, WINDOWS_GET,
-  TABS_CREATE, TABS_SELECT_AT, TABS_GET, TABS_UPDATE,
+  TABS_CREATE, TABS_SELECT_AT, TABS_GET, TABS_UPDATE, TABS_REMOVE,
   TABS_GET_ZOOM, TABS_SET_ZOOM,
   EVENT_KEYPRESS, EVENT_KEYDOWN, EVENT_KEYUP,
   SCROLL_GET, SCROLL_SET,
@@ -30,6 +30,8 @@ receiveContentMessage((message) => {
     return browser.tabs.get(message.tabId);
   case TABS_UPDATE:
     return browser.tabs.update(message.tabId, message.properties);
+  case TABS_REMOVE:
+    return browser.tabs.remove(message.tabId);
   case TABS_GET_ZOOM:
     return browser.tabs.getZoom(message.tabId);
   case TABS_SET_ZOOM:

--- a/e2e/ambassador/src/client/tabs.js
+++ b/e2e/ambassador/src/client/tabs.js
@@ -1,5 +1,5 @@
 import {
-  TABS_CREATE, TABS_SELECT_AT, TABS_GET, TABS_UPDATE,
+  TABS_CREATE, TABS_SELECT_AT, TABS_GET, TABS_UPDATE, TABS_REMOVE,
   TABS_GET_ZOOM, TABS_SET_ZOOM,
 } from '../shared/messages';
 import * as ipc from './ipc';
@@ -35,6 +35,13 @@ const update = (tabId, properties) => {
   });
 };
 
+const remove = (tabId) => {
+  return ipc.send({
+    type: TABS_REMOVE,
+    tabId
+  });
+};
+
 const getZoom = (tabId) => {
   return ipc.send({
     tabId,
@@ -50,4 +57,4 @@ const setZoom = (tabId, factor) => {
   });
 };
 
-export { create, selectAt, get, update, getZoom, setZoom };
+export { create, selectAt, get, update, remove, getZoom, setZoom };

--- a/e2e/ambassador/src/shared/messages.js
+++ b/e2e/ambassador/src/shared/messages.js
@@ -7,6 +7,7 @@ const TABS_CREATE = 'tabs.create';
 const TABS_SELECT_AT = 'tabs.selectAt';
 const TABS_GET = 'tabs.get';
 const TABS_UPDATE = 'tabs.update';
+const TABS_REMOVE = 'tabs.remove';
 const TABS_GET_ZOOM = 'tabs.get.zoom';
 const TABS_SET_ZOOM = 'tabs.set.zoom';
 const EVENT_KEYPRESS = 'event.keypress';
@@ -29,6 +30,7 @@ export {
   TABS_SELECT_AT,
   TABS_GET_ZOOM,
   TABS_SET_ZOOM,
+  TABS_REMOVE,
 
   EVENT_KEYPRESS,
   EVENT_KEYDOWN,

--- a/e2e/contents/mark.test.js
+++ b/e2e/contents/mark.test.js
@@ -1,0 +1,71 @@
+import * as windows from "../ambassador/src/client/windows";
+import * as tabs from "../ambassador/src/client/tabs";
+import * as keys from "../ambassador/src/client/keys";
+import * as scrolls from "../ambassador/src/client/scrolls";
+import { CLIENT_URL } from '../web-server/url';
+
+describe("mark test", () => {
+  let targetWindow;
+
+  before(async () => {
+    targetWindow = await windows.create();
+  });
+
+  after(async () => {
+    await windows.remove(targetWindow.id);
+  });
+
+  it('set a local mark and jump to it', async () => {
+    let tab = await tabs.create(targetWindow.id, CLIENT_URL + '/mark#local');
+    await scrolls.set(tab.id, 100, 100);
+    await keys.press(tab.id, 'm');
+    await keys.press(tab.id, 'a');
+
+    await scrolls.set(tab.id, 200, 200);
+    await keys.press(tab.id, "'");
+    await keys.press(tab.id, 'a');
+
+    let scroll = await scrolls.get(tab.id);
+    expect(scroll.x).to.be.equals(100);
+    expect(scroll.y).to.be.equals(100);
+  });
+
+  it('set a global mark and jump to it', async () => {
+    let tab1 = await tabs.create(targetWindow.id, CLIENT_URL + '/mark#global1');
+    await scrolls.set(tab1.id, 100, 100);
+    await keys.press(tab1.id, 'm');
+    await keys.press(tab1.id, 'A');
+    await new Promise(resolve => { setTimeout(() => resolve(), 100) });
+    await scrolls.set(tab1.id, 200, 200);
+
+    let tab2 = await tabs.create(targetWindow.id, CLIENT_URL + '/mark#global2');
+    await keys.press(tab2.id, "'");
+    await keys.press(tab2.id, 'A');
+    await new Promise(resolve => { setTimeout(() => resolve(), 100) });
+
+    tab1 = await tabs.get(tab1.id);
+    expect(tab1.active).to.be.true;
+    let scroll = await scrolls.get(tab1.id);
+    expect(scroll.x).to.be.equals(100);
+    expect(scroll.y).to.be.equals(100);
+  });
+
+  it('set a global mark and creates new tab from gone', async () => {
+    let tab1 = await tabs.create(targetWindow.id, CLIENT_URL + '/mark#gone');
+    await scrolls.set(tab1.id, 100, 100);
+    await keys.press(tab1.id, 'm');
+    await keys.press(tab1.id, 'A');
+    await tabs.remove(tab1.id);
+    await new Promise(resolve => { setTimeout(() => resolve(), 100) });
+
+    let tab2 = await tabs.create(targetWindow.id, CLIENT_URL + '/mark#newtab');
+    await keys.press(tab2.id, "'");
+    await keys.press(tab2.id, 'A');
+    await new Promise(resolve => { setTimeout(() => resolve(), 100) });
+
+    let win = await windows.get(targetWindow.id);
+    let found = win.tabs.find(tab => tab.url === CLIENT_URL + '/mark#gone')
+    expect(found).to.be.an('object');
+    expect(found.id).to.not.equal(tab1.id);
+  });
+});

--- a/e2e/contents/zoom.test.js
+++ b/e2e/contents/zoom.test.js
@@ -23,6 +23,7 @@ describe("zoom test", () => {
     let before = await tabs.getZoom(targetTab.id);
     await keys.press(targetTab.id, 'z');
     await keys.press(targetTab.id, 'i');
+    await new Promise(resolve => setTimeout(resolve, 100));
 
     let actual = await tabs.getZoom(targetTab.id);
     expect(actual).to.be.greaterThan(before);
@@ -32,6 +33,7 @@ describe("zoom test", () => {
     let before = await tabs.getZoom(targetTab.id);
     await keys.press(targetTab.id, 'z');
     await keys.press(targetTab.id, 'o');
+    await new Promise(resolve => setTimeout(resolve, 100));
 
     let actual = await tabs.getZoom(targetTab.id);
     expect(actual).to.be.lessThan(before);
@@ -42,6 +44,7 @@ describe("zoom test", () => {
     let before = await tabs.getZoom(targetTab.id);
     await keys.press(targetTab.id, 'z');
     await keys.press(targetTab.id, 'z');
+    await new Promise(resolve => setTimeout(resolve, 100));
 
     let actual = await tabs.getZoom(targetTab.id);
     expect(actual).to.be.lessThan(before);

--- a/e2e/web-server/index.js
+++ b/e2e/web-server/index.js
@@ -72,7 +72,7 @@ http.createServer(function (req, res) {
   }
 
   let u = url.parse(req.url);
-  if (u.pathname === '/scroll') {
+  if (u.pathname === '/scroll' || u.pathname === '/mark') {
     handleScroll(req, res);
   } else if (u.pathname === '/a-pagenation') {
     handleAPagenation(req, res);

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "sass-loader": "^7.1.0",
     "sinon-chrome": "^2.3.2",
     "style-loader": "^0.22.0",
-    "web-ext": "github:ueokande/web-ext#patched-2.7.0",
+    "web-ext": "github:ueokande/web-ext#patched-2.9.1",
     "webextensions-api-fake": "^0.5.1",
     "webpack": "^4.20.2",
     "webpack-cli": "^3.1.2"

--- a/src/background/usecases/completions.js
+++ b/src/background/usecases/completions.js
@@ -39,7 +39,8 @@ export default class CompletionsInteractor {
     let settings = await this.settingRepository.get();
     let groups = [];
 
-    for (let c of settings.properties.complete) {
+    let complete = settings.properties.complete || properties.defaults.complete;
+    for (let c of complete) {
       if (c === 's') {
         // eslint-disable-next-line no-await-in-loop
         let engines = await this.querySearchEngineItems(name, keywords);

--- a/src/console/components/console.js
+++ b/src/console/components/console.js
@@ -97,9 +97,12 @@ export default class ConsoleComponent {
   }
 
   onInput(e) {
+    let state = this.store.getState();
     let text = e.target.value;
     this.store.dispatch(consoleActions.setConsoleText(text));
-    this.store.dispatch(consoleActions.getCompletions(text));
+    if (state.mode === 'command') {
+      this.store.dispatch(consoleActions.getCompletions(text));
+    }
   }
 
   onInputShown(state) {

--- a/src/shared/settings/properties.js
+++ b/src/shared/settings/properties.js
@@ -12,7 +12,7 @@ const types = {
 const defaults = {
   hintchars: 'abcdefghijklmnopqrstuvwxyz',
   smoothscroll: false,
-  complete: 'sbn',
+  complete: 'sbh',
 };
 
 const docs = {


### PR DESCRIPTION
## Checklist for testing Vim Vixen

### Keybindings in JSON settings

Test operations with default key maps.

#### Console

The behaviors of the console are tested in [Console section](#consoles).

- [x] <kbd>:</kbd>: open empty console
- [x] <kbd>o</kbd>, <kbd>t</kbd>, <kbd>w</kbd>: open a console with `open`, `tabopen`, `winopen`
- [x] <kbd>O</kbd>, <kbd>T</kbd>, <kbd>W</kbd>: open a console with `open`, `tabopen`, `winopen` and current URL
- [x] <kbd>b</kbd>: open a console with `buffer`
- [x] <kbd>a</kbd>: open a console with `addbookmark` and the current page's title

#### Tabs

- [x] <kbd>r</kbd>: reload current tab
- [x] <kbd>R</kbd>: reload current tab without cache

#### Misc

- [x] <kbd>y</kbd>: yank current URL and show a message
- [x] <kbd>p</kbd>: open clipboard's URL in current tab
- [x] <kbd>P</kbd>: open clipboard's URL in new tab
- [x] <kbd>p</kbd>: search clipboard's keywords in current tab
- [x] <kbd>P</kbd>: search clipboard's keywords in new tab
- [x] Toggle enabled/disabled of plugin bu <kbd>Shift</kbd>+<kbd>Esc</kbd>
- [x] Hide error and info console by <kbd>Esc</kbd>
- [x] Vim-Vixen icons changes on <kbd>Shift</kbd>+<kbd>Esc</kbd>
- [x] Add-on is enabled and disabled by clicking the indicator on the tool bar.
- [x] The indicator changed on selected tab changed (changes add-on enabled)
- [x] Notify to users on add-on updated at first time.

### Following links

- [x] Show hints on following on a page containing `<frame>`/`<iframe>`
- [x] Show hints only inside viewport of the frame on following on a page containing `<frame>`/`<iframe>`
- [x] Show hints only inside top window on following on a page containing `<frame>`/`<iframe>`
- [x] Select link and open it in the frame in `<iframe>`/`<frame`> on following by <kbd>f</kbd>
- [x] Select link and open it in new tab in `<iframe>`/`<frame`> on following by <kbd>F</kbd>
- [x] Select link and open it in `<area>` tags, for <kbd>f</kbd> and <kbd>F</kbd>
- [x] Open new tab in background by `"background": true`

### Consoles

#### Exec a command

- [x] `<EMPTY>`: do nothing
<br>

- [x] `open an apple`: search with keywords "an apple" by default search engine (google)
- [x] `open github.com`: open github.com
- [x] `open https://github.com`: open github.com
- [x] `open yahoo an apple`: search with keywords "an apple" by yahoo.com
- [x] `open yahoo`: search with empty keywords; yahoo redirects to top page
- [x] `open`: open default search engine
<br>

- [x] `tabopen`: do above tests replaced `open` with `tabopen`, and verify the page is opened in new tab
- [x] `winopen`: do above tests replaced `open` with `winopen`, and verify the page is opened in new window
<br>

- [x] `buffer`: do nothing
- [x] `buffer <title>`, `buffer <url>`: select tab which has an title matched with
- [x] `buffer 1`: select leftmost tab
- [x] `buffer 0`, `buffer <a number more than count of tabs>`: shows an error
- [x] select tabs rotationally when more than two tabs are matched
- [x] `buffer %`: select current tab (nothing to do)
- [x] `buffer #`: select last selected tab
<br>

- [x] `addbookmark` creates a bookmark
<br>

- [x] `q`, `quit`: close current tab
- [x] `qa`, `quitall`: close all tabs
- [x] `bdelete`: delete a not-pinned tab matches with keywords
- [x] `bdelete`: show errors no-tabs or more than 1 tabs matched
- [x] `bdelete`: can not delete pinned tab
- [x] `bdelete!`: delete a tab matches with keywords
- [x] `bdelete!`: delete a pinned tab matches with keywords
- [x] `bdeletes`: delete tabs with matched with keywords excluding pinned
- [x] `bdeletes!`: delete tabs with matched with keywords including pinned

### Completions

#### History and search engines

- [x] `open<SP>`: show all engines and some history items
- [x] `open g`: complete search engines starts with `g` and matched with keywords `g`
- [x] `open foo bar`: complete history items matched with keywords `foo` and `bar`
- [x] `set `: show prperties starts with keywords
- [x] The completions shows histories, search engines, and bookmarks.
- [x] also `tabopen` and `winopen`
- shortening commands such as `o` are not test in this release
- [x] Complete commands matched with input keywords in the prefix.

#### Buffer command

- [x] `buffer<SP>`: show all opened tabs in completion
- [x] `buffer x`: show tabs which has title and URL matches with `x`
- [x] shows tab index and marks

#### Buffer command

- [x] `bdelete`, `bdeletes`: show tabs excluding pinned tabs
- [x] `bdelete!`, `bdeletes!`: show tabs including pinned tabs

#### Misc

- [x] Select next item by <kbd>Tab</kbd> and previous item by <kbd>Shift</kbd>+<kbd>Tab</kbd>
- [x] Reopen tab on *only current window* by <kbd>u</kbd>

### Properties

- [x] Configure custom hint character by `:set hintchars=012345678`
- [x] Configure custom hint character by settings `"hintchars": "012345678"` in add-on preferences
- [x] Opened tabs is in child on Tree Style Tab
- [x] Smooth scroll by `:set smoothscroll`
- [x] Non-smooth scroll by `:set nosmoothscroll`
- [x] Configure smooth scroll by settings `"smoothscroll": true`, `"smoothscroll": false`
- [x] Show search engine, bookmark and history items in order by `:set complete=sbh`
- [x] Show bookmark, search engine, and search engine items in order by `:set complete=bss`
- [x] Configure completion items by setting `"complete": "sbh"`, `"complete": "bss"`

### Settings

#### JSON Settings

##### Validations

- [x] show error on invalid json
- [x] show error when top-level keys has keys other than `keymaps`, `search`, `blacklist`, and `properties`

###### `"keymaps"` section

- [x] show error on unknown operation name in `"keymaps"`

###### `"search"` section

- validations in `"search"` section are not tested in this release

##### `"blacklist"` section

- [x] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
- [x] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
- [x] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
- [x] `github.com` blocks both `github.com/` and `github.com/a`
- [x] `*.github.com` blocks `gist.github.com/`, and not `github.com`

##### Updating

- [x] changes are updated on textarea blure when no errors
- [x] changes are not updated on textarea blure when errors occurs
- [x] keymap settings are applied to open tabs without reload
- [x] search settings are applied to open tabs without reload

##### Properties

- [x] show errors when invalid property name
- [x] show errors when invalid property type

#### Form Settings

<!-- validation on form settings does not implement in 0.7 -->

##### Search Engines

- [x] able to change default
- [x] able to remove item
- [x] able to add item

##### `"blacklist"` section

- [x] able to add item
- [x] able to remove item
- [x] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
- [x] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
- [x] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
- [x] `github.com` blocks both `github.com/` and `github.com/a`
- [x] `*.github.com` blocks `gist.github.com/`, and not `github.com`

##### Updating

- [x] keymap settings are applied to open tabs without reload
- [x] search settings are applied to open tabs without reload

### Settings source

- [x] show confirmation dialog on switched from json to form
- [x] state is saved on source changed
- [x] on switching form -> json -> form, first and last form setting is equivalent to first one

### For certain sites

- [x] scroll on Hacker News
- [x] able to scroll on Gmail and Slack
- [x] Focus text box on Twitter or Slack, press <kbd>j</kbd>, then <kbd>j</kbd> is typed in the box
- [x] Focus the text box on Twitter or Slack on following mode
- [x] The pages is shown in https://pitchify.com/
- [x] Open console in http://www.espncricinfo.com/

## Find mode

- [x] open console with <kbd>/</kbd>
- [x] highlight a word on <kbd>Enter</kbd> pressed in find console
- [x] Search next/prev by <kbd>n</kbd>/<kbd>N</kbd>
- [x] Wrap search by <kbd>n</kbd>/<kbd>N</kbd>
- [x] Find with last keyword if keyword is empty
- [x] Find keyword last used on new tab opened

## Misc

- [x] Work on `about:blank`
- [x] Able to map `<A-Z>` key.
- [x] Open file menu by <kbd>Alt</kbd>+<kbd>F</kbd> (Other than Mac OS)
