### PR TITLE
Support blacklist with port

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -69,14 +69,6 @@ The behaviors of the console are tested in [Console section](#consoles).
 
 - validations in `"search"` section are not tested in this release
 
-##### `"blacklist"` section
-
-- [ ] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
-- [ ] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
-- [ ] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
-- [ ] `github.com` blocks both `github.com/` and `github.com/a`
-- [ ] `*.github.com` blocks `gist.github.com/`, and not `github.com`
-
 ##### Updating
 
 - [ ] changes are updated on textarea blure when no errors

--- a/e2e/blacklist.test.js
+++ b/e2e/blacklist.test.js
@@ -1,0 +1,77 @@
+const express = require('express');
+const lanthan = require('lanthan');
+const path = require('path');
+const assert = require('assert');
+const settings = require('./settings');
+
+const newApp = () => {
+  let app = express();
+  app.get('/*', (req, res) => {
+    res.status(200).send(`<!DOCTYPEhtml>
+<html lang="en">
+  <body style="width:10000px; height:10000px"></body>
+</html>`);
+  });
+  return app;
+};
+
+describe("navigate test", () => {
+
+  const port = 12321;
+  let http;
+  let firefox;
+  let session;
+  let browser;
+
+  before(async() => {
+    http = newApp().listen(port);
+
+    firefox = await lanthan.firefox({
+      spy: path.join(__dirname, '..'),
+      builderf: (builder) => {
+        builder.addFile('build/settings.js');
+      },
+    });
+    session = firefox.session;
+    browser = firefox.browser;
+  });
+
+  after(async() => {
+    if (firefox) {
+      await firefox.close();
+    }
+    http.close();
+  });
+
+  it('should disable add-on if the URL is in the blacklist', async () => {
+    await browser.storage.local.set({
+      settings: {
+        source: 'json',
+        json: `{
+        "keymaps": {
+          "j": { "type": "scroll.vertically", "count": 1 }
+        },
+        "blacklist": [ "127.0.0.1:${port}/a" ]
+      }`,
+      },
+    });
+
+    await session.navigateTo(`http://127.0.0.1:${port}/a`);
+
+    let body = await session.findElementByCSS('body');
+    await body.sendKeys('j');
+
+    // not works
+    let pageYOffset = await session.executeScript(() => window.pageYOffset);
+    assert.equal(pageYOffset, 0);
+
+    await session.navigateTo(`http://127.0.0.1:${port}/ab`);
+    body = await session.findElementByCSS('body');
+    await body.sendKeys('j');
+
+    // works
+    pageYOffset = await session.executeScript(() => window.pageYOffset);
+    assert.equal(pageYOffset, 64);
+  });
+});
+

--- a/src/shared/blacklists.js
+++ b/src/shared/blacklists.js
@@ -4,9 +4,9 @@ const includes = (blacklist, url) => {
   let u = new URL(url);
   return blacklist.some((item) => {
     if (!item.includes('/')) {
-      return re.fromWildcard(item).test(u.hostname);
+      return re.fromWildcard(item).test(u.host);
     }
-    return re.fromWildcard(item).test(u.hostname + u.pathname);
+    return re.fromWildcard(item).test(u.host + u.pathname);
   });
 };
 

--- a/test/shared/blacklists.test.js
+++ b/test/shared/blacklists.test.js
@@ -39,4 +39,11 @@ describe("shared/blacklist", () => {
     expect(includes(blacklist, 'https://github.com/abcdef')).to.be.true;
     expect(includes(blacklist, 'https://gist.github.com/abc')).to.be.false;
   })
+
+  it('matches address and port', () => {
+    let blacklist = ['127.0.0.1:8888'];
+
+    expect(includes(blacklist, 'http://127.0.0.1:8888/')).to.be.true;
+    expect(includes(blacklist, 'http://127.0.0.1:8888/hello')).to.be.true;
+  })
 });


### PR DESCRIPTION
close #483

Support to specify port to the blacklist, such as `127.0.0.1:8080`.