### PR TITLE
QA 0.22

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -69,10 +69,6 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] able to add item
 - [ ] able to remove item
 - [ ] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`
-- [ ] `github.com/a*` blocks both `github.com/a` and `github.com/aa`
-- [ ] `github.com/` blocks `github.com/`, and not blocks `github.com/a`
-- [ ] `github.com` blocks both `github.com/` and `github.com/a`
-- [ ] `*.github.com` blocks `gist.github.com/`, and not `github.com`
 
 ##### Updating
 
@@ -84,15 +80,6 @@ The behaviors of the console are tested in [Console section](#consoles).
 - [ ] show confirmation dialog on switched from json to form
 - [ ] state is saved on source changed
 - [ ] on switching form -> json -> form, first and last form setting is equivalent to first one
-
-### For certain sites
-
-- [ ] scroll on Hacker News
-- [ ] able to scroll on Gmail and Slack
-- [ ] Focus text box on Twitter or Slack, press <kbd>j</kbd>, then <kbd>j</kbd> is typed in the box
-- [ ] Focus the text box on Twitter or Slack on following mode
-- [ ] The pages is shown in https://pitchify.com/
-- [ ] Open console in http://www.espncricinfo.com/
 
 ## Find mode
 


### PR DESCRIPTION
## Checklist for testing Vim Vixen

### Keybindings in JSON settings

Test operations with default key maps.

#### Console

The behaviors of the console are tested in [Console section](#consoles).

#### Misc

- [x] Toggle enabled/disabled of plugin bu <kbd>Shift</kbd>+<kbd>Esc</kbd>
- [x] Hide error and info console by <kbd>Esc</kbd>
- [x] Vim-Vixen icons changes on <kbd>Shift</kbd>+<kbd>Esc</kbd>
- [x] Add-on is enabled and disabled by clicking the indicator on the tool bar.
- [x] The indicator changed on selected tab changed (changes add-on enabled)
- [x] Notify to users on add-on updated at first time.
- [x] Reopen tab on *only current window* by <kbd>u</kbd>

### Properties

- [x] Configure custom hint character by `:set hintchars=012345678`
- [x] Smooth scroll by `:set smoothscroll`
- [x] Non-smooth scroll by `:set nosmoothscroll`
- [x] Configure smooth scroll by settings `"smoothscroll": true`, `"smoothscroll": false`

### Settings

#### JSON Settings

##### Validations

- [x] show error on invalid json
- [x] show error when top-level keys has keys other than `keymaps`, `search`, `blacklist`, and `properties`

###### `"keymaps"` section

- [x] show error on unknown operation name in `"keymaps"`

###### `"search"` section

- validations in `"search"` section are not tested in this release

##### Updating

- [x] changes are updated on textarea blure when no errors
- [x] changes are not updated on textarea blure when errors occurs
- [x] keymap settings are applied to open tabs without reload
- [x] search settings are applied to open tabs without reload

##### Properties

- [x] show errors when invalid property name
- [x] show errors when invalid property type

#### Form Settings

<!-- validation on form settings does not implement in 0.7 -->

##### Search Engines

- [x] able to change default
- [x] able to remove item
- [x] able to add item

##### `"blacklist"` section

- [x] able to add item
- [x] able to remove item
- [x] `github.com/a` blocks `github.com/a`, and not blocks `github.com/aa`

##### Updating

- [x] keymap settings are applied to open tabs without reload
- [x] search settings are applied to open tabs without reload

### Settings source

- [x] show confirmation dialog on switched from json to form
- [x] state is saved on source changed
- [x] on switching form -> json -> form, first and last form setting is equivalent to first one

## Find mode

- [x] open console with <kbd>/</kbd>
- [x] highlight a word on <kbd>Enter</kbd> pressed in find console
- [x] Search next/prev by <kbd>n</kbd>/<kbd>N</kbd>
- [x] Wrap search by <kbd>n</kbd>/<kbd>N</kbd>
- [x] Find with last keyword if keyword is empty
- [x] Find keyword last used on new tab opened

## Misc

- [x] Work on `about:blank`
- [x] Able to map `<A-Z>` key.
- [x] Open file menu by <kbd>Alt</kbd>+<kbd>F</kbd> (Other than Mac OS)