### PR TITLE
Fix warnings on Android

### DIFF
--- a/src/background/presenters/IndicatorPresenter.ts
+++ b/src/background/presenters/IndicatorPresenter.ts
@@ -3,7 +3,13 @@ export default class IndicatorPresenter {
     let path = enabled
       ? 'resources/enabled_32x32.png'
       : 'resources/disabled_32x32.png';
-    return browser.browserAction.setIcon({ path });
+    if (typeof browser.browserAction.setIcon === "function") {
+      return browser.browserAction.setIcon({ path });
+    }
+    else {
+      // setIcon not supported on Android
+      return Promise.resolve();
+    }
   }
 
   onClick(listener: (arg: browser.tabs.Tab) => void): void {

--- a/src/background/usecases/CompletionsUseCase.ts
+++ b/src/background/usecases/CompletionsUseCase.ts
@@ -52,13 +52,15 @@ export default class CompletionsUseCase {
         if (engines.length > 0) {
           groups.push({ name: 'Search Engines', items: engines });
         }
-      } else if (c === 'h') {
+        // browser.history not supported on Android
+      } else if (c === 'h' && typeof browser.history === "object") {
         // eslint-disable-next-line no-await-in-loop
         let histories = await this.queryHistoryItems(name, keywords);
         if (histories.length > 0) {
           groups.push({ name: 'History', items: histories });
         }
-      } else if (c === 'b') {
+        // browser.bookmarks not supported on Android
+      } else if (c === 'b' && typeof browser.bookmarks === "object") {
         // eslint-disable-next-line no-await-in-loop
         let bookmarks = await this.queryBookmarkItems(name, keywords);
         if (bookmarks.length > 0) {

--- a/src/background/usecases/LinkUseCase.ts
+++ b/src/background/usecases/LinkUseCase.ts
@@ -12,8 +12,9 @@ export default class LinkUseCase {
   }
 
   openNewTab(url: string, openerId: number, background: boolean): Promise<any> {
-    return this.tabPresenter.create(url, {
-      openerTabId: openerId, active: !background
-    });
+    // openerTabId not supported on Android
+    let properties = typeof browser.tabs.Tab === "object" ?
+      { openerTabId: openerId, active: !background } : { active: !background };
+    return this.tabPresenter.create(url, properties);
   }
 }


### PR DESCRIPTION
Because some WebExtension APIs have not yet been implemented in Firefox for Android, Vim Vixen will break when it tries to use them and displays warning messages.

This pull request makes the core features of Vim Vixen usable on Android.

I have not tested on platforms other than Android and have no prior experience with web development, so please review and test. 