### PR TITLE
Add a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,683 @@
+# Changelog
+
+## [Unreleased](https://github.com/ueokande/vim-vixen/tree/HEAD)
+
+**Closed issues:**
+
+- Disable Showing History/Bookmark in 'open' command [\#615](https://github.com/ueokande/vim-vixen/issues/615)
+- Add :help to open commands list [\#605](https://github.com/ueokande/vim-vixen/issues/605)
+- Preferences broken [\#599](https://github.com/ueokande/vim-vixen/issues/599)
+- Kindle Cloud Reader doesn't load books since 0.22 [\#577](https://github.com/ueokande/vim-vixen/issues/577)
+- JavaScript error on stdout [\#548](https://github.com/ueokande/vim-vixen/issues/548)
+
+## [0.23](https://github.com/ueokande/vim-vixen/tree/0.23) (2019-05-29)
+
+**Implemented enhancements:**
+
+- Support Firefox for Android \(Fennec\) [\#463](https://github.com/ueokande/vim-vixen/issues/463)
+- Feature Request: Repeat Actions n times / repeat with '.' [\#177](https://github.com/ueokande/vim-vixen/issues/177)
+
+**Fixed bugs:**
+
+- "Open Page Source" 2x in preferences [\#554](https://github.com/ueokande/vim-vixen/issues/554)
+
+**Closed issues:**
+
+- Vim Vixen could not be verified for use in FireFox Developer Edition [\#582](https://github.com/ueokande/vim-vixen/issues/582)
+- Addon enabled, but not functioning since Firefox 66.0.4 fix on Windows [\#581](https://github.com/ueokande/vim-vixen/issues/581)
+- VimVixen breaks Storybook [\#549](https://github.com/ueokande/vim-vixen/issues/549)
+
+**Merged pull requests:**
+
+- QA 0.23 [\#596](https://github.com/ueokande/vim-vixen/pull/596) ([ueokande](https://github.com/ueokande))
+- Fix duplicated form [\#594](https://github.com/ueokande/vim-vixen/pull/594) ([ueokande](https://github.com/ueokande))
+- Add "repeat last operation" command [\#592](https://github.com/ueokande/vim-vixen/pull/592) ([ueokande](https://github.com/ueokande))
+- Remove unnecessary semi [\#590](https://github.com/ueokande/vim-vixen/pull/590) ([ueokande](https://github.com/ueokande))
+- Use tsyringe for DI container [\#588](https://github.com/ueokande/vim-vixen/pull/588) ([ueokande](https://github.com/ueokande))
+- Refactor content scripts [\#587](https://github.com/ueokande/vim-vixen/pull/587) ([ueokande](https://github.com/ueokande))
+- Fix warnings on Android [\#586](https://github.com/ueokande/vim-vixen/pull/586) ([robsmith11](https://github.com/robsmith11))
+- Move to TypeScript [\#578](https://github.com/ueokande/vim-vixen/pull/578) ([ueokande](https://github.com/ueokande))
+- Move to React [\#576](https://github.com/ueokande/vim-vixen/pull/576) ([ueokande](https://github.com/ueokande))
+
+## [0.22](https://github.com/ueokande/vim-vixen/tree/0.22) (2019-04-27)
+
+**Fixed bugs:**
+
+- Blacklist pages on certain port [\#483](https://github.com/ueokande/vim-vixen/issues/483)
+- Console dos not show on webseite with restrective CSP Policy [\#189](https://github.com/ueokande/vim-vixen/issues/189)
+
+**Closed issues:**
+
+- Please remove or change D shorcut [\#563](https://github.com/ueokande/vim-vixen/issues/563)
+- Vim Vixen breaks hexed.it [\#558](https://github.com/ueokande/vim-vixen/issues/558)
+
+**Merged pull requests:**
+
+- QA 0.22 [\#575](https://github.com/ueokande/vim-vixen/pull/575) ([ueokande](https://github.com/ueokande))
+- Update packages [\#574](https://github.com/ueokande/vim-vixen/pull/574) ([ueokande](https://github.com/ueokande))
+- Use JSZIP [\#572](https://github.com/ueokande/vim-vixen/pull/572) ([ueokande](https://github.com/ueokande))
+- Fix Content-Security-Policy issues [\#571](https://github.com/ueokande/vim-vixen/pull/571) ([ueokande](https://github.com/ueokande))
+- fix typos in README.md [\#570](https://github.com/ueokande/vim-vixen/pull/570) ([nixon](https://github.com/nixon))
+- Add e2e tests [\#568](https://github.com/ueokande/vim-vixen/pull/568) ([ueokande](https://github.com/ueokande))
+- Support blacklist with port [\#567](https://github.com/ueokande/vim-vixen/pull/567) ([ueokande](https://github.com/ueokande))
+- Add e2e tests [\#565](https://github.com/ueokande/vim-vixen/pull/565) ([ueokande](https://github.com/ueokande))
+- Use lanthan to do E2E testing [\#564](https://github.com/ueokande/vim-vixen/pull/564) ([ueokande](https://github.com/ueokande))
+- Show yanked url [\#562](https://github.com/ueokande/vim-vixen/pull/562) ([aminroosta](https://github.com/aminroosta))
+- Replace E2E tests with lanthan [\#559](https://github.com/ueokande/vim-vixen/pull/559) ([ueokande](https://github.com/ueokande))
+
+## [0.21](https://github.com/ueokande/vim-vixen/tree/0.21) (2019-03-23)
+
+**Fixed bugs:**
+
+- Unexpected error occurs when opening a page [\#531](https://github.com/ueokande/vim-vixen/issues/531)
+- Question: How to bind Ctrl-Space [\#493](https://github.com/ueokande/vim-vixen/issues/493)
+- Smooth scroll is not smooth [\#425](https://github.com/ueokande/vim-vixen/issues/425)
+- :buffer does not show all open tabs [\#281](https://github.com/ueokande/vim-vixen/issues/281)
+
+**Closed issues:**
+
+- Follow link box with 'j' remains [\#555](https://github.com/ueokande/vim-vixen/issues/555)
+- Spelling error [\#534](https://github.com/ueokande/vim-vixen/issues/534)
+
+**Merged pull requests:**
+
+- Update documents [\#552](https://github.com/ueokande/vim-vixen/pull/552) ([TeepaBlue](https://github.com/TeepaBlue))
+- QA 0.21 [\#547](https://github.com/ueokande/vim-vixen/pull/547) ([ueokande](https://github.com/ueokande))
+- Refactor background [\#544](https://github.com/ueokande/vim-vixen/pull/544) ([ueokande](https://github.com/ueokande))
+- Update README.md [\#543](https://github.com/ueokande/vim-vixen/pull/543) ([ryanstreur](https://github.com/ryanstreur))
+- Use browser.runtime.onInstalled event [\#539](https://github.com/ueokande/vim-vixen/pull/539) ([ueokande](https://github.com/ueokande))
+- Scroll console [\#538](https://github.com/ueokande/vim-vixen/pull/538) ([ueokande](https://github.com/ueokande))
+- Space key map [\#537](https://github.com/ueokande/vim-vixen/pull/537) ([ueokande](https://github.com/ueokande))
+- Make smooth-scroll smoother [\#536](https://github.com/ueokande/vim-vixen/pull/536) ([ueokande](https://github.com/ueokande))
+- Correct spelling of WebExtensions [\#535](https://github.com/ueokande/vim-vixen/pull/535) ([sleepypikachu](https://github.com/sleepypikachu))
+
+## [0.20](https://github.com/ueokande/vim-vixen/tree/0.20) (2019-02-04)
+
+**Implemented enhancements:**
+
+- Ability to change the colors and font [\#176](https://github.com/ueokande/vim-vixen/issues/176)
+- setting for consoole-font mixin [\#105](https://github.com/ueokande/vim-vixen/issues/105)
+- Close all tabs right to current one [\#371](https://github.com/ueokande/vim-vixen/issues/371)
+
+**Fixed bugs:**
+
+- Vim Vixen allows websites to show glorified cat harness ads in the console [\#251](https://github.com/ueokande/vim-vixen/issues/251)
+
+**Closed issues:**
+
+- Add support for read mode [\#527](https://github.com/ueokande/vim-vixen/issues/527)
+- Night mode \[SUGGESTION\] [\#525](https://github.com/ueokande/vim-vixen/issues/525)
+- select item of completion [\#522](https://github.com/ueokande/vim-vixen/issues/522)
+- Console is always visible on Lodash documentation [\#519](https://github.com/ueokande/vim-vixen/issues/519)
+- Alternate Color Scheme for Dark Reader [\#514](https://github.com/ueokande/vim-vixen/issues/514)
+- Fails to open the console correctly on PyPi.org [\#503](https://github.com/ueokande/vim-vixen/issues/503)
+- Way to unfocus url search bar? [\#501](https://github.com/ueokande/vim-vixen/issues/501)
+- Can't follow single char hints when there are many links [\#499](https://github.com/ueokande/vim-vixen/issues/499)
+- Incremental Search [\#498](https://github.com/ueokande/vim-vixen/issues/498)
+- customize console colors [\#485](https://github.com/ueokande/vim-vixen/issues/485)
+- Please allow extend REL\_PATTERN in user configuration [\#482](https://github.com/ueokande/vim-vixen/issues/482)
+- Alternative hintchars setting [\#480](https://github.com/ueokande/vim-vixen/issues/480)
+- Question: Always display statusbar \(console\) with current URL? [\#479](https://github.com/ueokande/vim-vixen/issues/479)
+- Appears to be corrupt [\#428](https://github.com/ueokande/vim-vixen/issues/428)
+- Custom colors with a config file [\#400](https://github.com/ueokande/vim-vixen/issues/400)
+- Suggestions text too small [\#383](https://github.com/ueokande/vim-vixen/issues/383)
+- Filter labels like [\#336](https://github.com/ueokande/vim-vixen/issues/336)
+- Can't input text into search menu, buffer menu, or open menu [\#283](https://github.com/ueokande/vim-vixen/issues/283)
+- Increase horisontal padding on follow link hints [\#268](https://github.com/ueokande/vim-vixen/issues/268)
+- Blocks standard keybinding - does not provide an alternative. [\#181](https://github.com/ueokande/vim-vixen/issues/181)
+- Add keybinding to go to startpage [\#262](https://github.com/ueokande/vim-vixen/issues/262)
+
+**Merged pull requests:**
+
+- QA 0.20 [\#533](https://github.com/ueokande/vim-vixen/pull/533) ([ueokande](https://github.com/ueokande))
+- Update packages [\#532](https://github.com/ueokande/vim-vixen/pull/532) ([ueokande](https://github.com/ueokande))
+- fixed typo in README [\#524](https://github.com/ueokande/vim-vixen/pull/524) ([tsia](https://github.com/tsia))
+- added Hint how to select items from the completion list [\#523](https://github.com/ueokande/vim-vixen/pull/523) ([tsia](https://github.com/tsia))
+- Add close tabs to the right command [\#516](https://github.com/ueokande/vim-vixen/pull/516) ([ueokande](https://github.com/ueokande))
+- Open homepage [\#511](https://github.com/ueokande/vim-vixen/pull/511) ([ueokande](https://github.com/ueokande))
+- Window postmessage [\#507](https://github.com/ueokande/vim-vixen/pull/507) ([ueokande](https://github.com/ueokande))
+
+## [0.19](https://github.com/ueokande/vim-vixen/tree/0.19) (2018-10-20)
+
+**Implemented enhancements:**
+
+- Do we have control over completion suggestions? [\#68](https://github.com/ueokande/vim-vixen/issues/68)
+
+**Fixed bugs:**
+
+- :open with a single word containing a double colon produces a "problem loading page" [\#445](https://github.com/ueokande/vim-vixen/issues/445)
+
+**Closed issues:**
+
+- Doesn't respect default search engine [\#494](https://github.com/ueokande/vim-vixen/issues/494)
+- "Address was not understood" if the first search word ends with a ":" [\#481](https://github.com/ueokande/vim-vixen/issues/481)
+- Hide navigation bar [\#476](https://github.com/ueokande/vim-vixen/issues/476)
+- When hovering links url hint hides command [\#475](https://github.com/ueokande/vim-vixen/issues/475)
+- "An unexpected error occurred" on reopening a previously closed tab by pressing u. [\#474](https://github.com/ueokande/vim-vixen/issues/474)
+- Cannot open in new tab [\#471](https://github.com/ueokande/vim-vixen/issues/471)
+- Vixen not working on kotlin website [\#470](https://github.com/ueokande/vim-vixen/issues/470)
+- Can not open file: URL through :tabopen [\#458](https://github.com/ueokande/vim-vixen/issues/458)
+- :open shows a huge list of candidates [\#452](https://github.com/ueokande/vim-vixen/issues/452)
+- Remove adjacenttab property [\#446](https://github.com/ueokande/vim-vixen/issues/446)
+- Jump Marks [\#276](https://github.com/ueokande/vim-vixen/issues/276)
+
+**Merged pull requests:**
+
+- QA 0.19 [\#492](https://github.com/ueokande/vim-vixen/pull/492) ([ueokande](https://github.com/ueokande))
+- Update packages [\#491](https://github.com/ueokande/vim-vixen/pull/491) ([ueokande](https://github.com/ueokande))
+- CircleCI 2.1 [\#489](https://github.com/ueokande/vim-vixen/pull/489) ([ueokande](https://github.com/ueokande))
+- Remove adjacenttab [\#487](https://github.com/ueokande/vim-vixen/pull/487) ([ueokande](https://github.com/ueokande))
+- Support jump marks [\#486](https://github.com/ueokande/vim-vixen/pull/486) ([ueokande](https://github.com/ueokande))
+- Fix search keywords with colon [\#484](https://github.com/ueokande/vim-vixen/pull/484) ([ueokande](https://github.com/ueokande))
+- correct INPUT\_KEY\_PRESS action type name [\#466](https://github.com/ueokande/vim-vixen/pull/466) ([Stefanough](https://github.com/Stefanough))
+- rename modifierdKeyName to modifiedKeyName [\#465](https://github.com/ueokande/vim-vixen/pull/465) ([Stefanough](https://github.com/Stefanough))
+- Add complete property [\#461](https://github.com/ueokande/vim-vixen/pull/461) ([ueokande](https://github.com/ueokande))
+- Update style-loader to the latest version 🚀 [\#448](https://github.com/ueokande/vim-vixen/pull/448) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+
+## [0.18](https://github.com/ueokande/vim-vixen/tree/0.18) (2018-08-12)
+
+**Fixed bugs:**
+
+- Fatal error when using the console: e.trimStart is not a function [\#449](https://github.com/ueokande/vim-vixen/issues/449)
+
+**Closed issues:**
+
+- Would you please add mac os command key for mapping, thanks. [\#430](https://github.com/ueokande/vim-vixen/issues/430)
+
+**Merged pull requests:**
+
+- Limit bookmark items on completion [\#455](https://github.com/ueokande/vim-vixen/pull/455) ([ueokande](https://github.com/ueokande))
+- Fix typo in the buffer command's description [\#454](https://github.com/ueokande/vim-vixen/pull/454) ([cfillion](https://github.com/cfillion))
+
+## [0.17](https://github.com/ueokande/vim-vixen/tree/0.17) (2018-08-08)
+
+**Merged pull requests:**
+
+- Fix trim start [\#450](https://github.com/ueokande/vim-vixen/pull/450) ([ueokande](https://github.com/ueokande))
+
+## [0.16](https://github.com/ueokande/vim-vixen/tree/0.16) (2018-08-05)
+
+**Implemented enhancements:**
+
+- Add numbers to identify buffers. [\#213](https://github.com/ueokande/vim-vixen/issues/213)
+- Tab completion for console keywords [\#115](https://github.com/ueokande/vim-vixen/issues/115)
+- Buffer flags [\#9](https://github.com/ueokande/vim-vixen/issues/9)
+
+**Closed issues:**
+
+- \[Feature Request\] Use search engines from Firefox preferences [\#443](https://github.com/ueokande/vim-vixen/issues/443)
+- Key to open Home page [\#438](https://github.com/ueokande/vim-vixen/issues/438)
+- Hint key appeared alone and in combination at the same time [\#434](https://github.com/ueokande/vim-vixen/issues/434)
+- Feature: Add `Help Command` to see command list [\#433](https://github.com/ueokande/vim-vixen/issues/433)
+- Ctrl+U default keybinding conflicts with "show source" [\#377](https://github.com/ueokande/vim-vixen/issues/377)
+- Open tabs, windows without using the console [\#325](https://github.com/ueokande/vim-vixen/issues/325)
+- "p" shortcut  supports clipboard string search [\#408](https://github.com/ueokande/vim-vixen/issues/408)
+- Extend \#348 to implement :qa [\#398](https://github.com/ueokande/vim-vixen/issues/398)
+
+**Merged pull requests:**
+
+- Release 0.16 [\#447](https://github.com/ueokande/vim-vixen/pull/447) ([ueokande](https://github.com/ueokande))
+- QA 0.16 [\#444](https://github.com/ueokande/vim-vixen/pull/444) ([ueokande](https://github.com/ueokande))
+- Buffer flags [\#442](https://github.com/ueokande/vim-vixen/pull/442) ([ueokande](https://github.com/ueokande))
+- Search on paste [\#441](https://github.com/ueokande/vim-vixen/pull/441) ([ueokande](https://github.com/ueokande))
+- Background clean architecture [\#440](https://github.com/ueokande/vim-vixen/pull/440) ([ueokande](https://github.com/ueokande))
+- Allow following \<summary\> elements [\#432](https://github.com/ueokande/vim-vixen/pull/432) ([Mange](https://github.com/Mange))
+- Command completions [\#431](https://github.com/ueokande/vim-vixen/pull/431) ([ueokande](https://github.com/ueokande))
+- Use official redux [\#429](https://github.com/ueokande/vim-vixen/pull/429) ([ueokande](https://github.com/ueokande))
+- Update css-loader to the latest version 🚀 [\#424](https://github.com/ueokande/vim-vixen/pull/424) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Update eslint [\#423](https://github.com/ueokande/vim-vixen/pull/423) ([ueokande](https://github.com/ueokande))
+- Adds command to close all tabs [\#402](https://github.com/ueokande/vim-vixen/pull/402) ([jvbrandaom](https://github.com/jvbrandaom))
+
+## [0.15](https://github.com/ueokande/vim-vixen/tree/0.15) (2018-06-26)
+
+**Fixed bugs:**
+
+- Add-on doesn't verify on firefox 56 [\#108](https://github.com/ueokande/vim-vixen/issues/108)
+- 'n'/'N' keys should be ignored until '/' is pressed [\#396](https://github.com/ueokande/vim-vixen/issues/396)
+- Select tabs by URL or title does not work [\#352](https://github.com/ueokande/vim-vixen/issues/352)
+- "u" operation sometimes acts on a window that isn't focused [\#77](https://github.com/ueokande/vim-vixen/issues/77)
+
+**Closed issues:**
+
+- Use G/gg to go to bottom/top of page [\#409](https://github.com/ueokande/vim-vixen/issues/409)
+- Invalid size and appearance of iframe with vim-vixen console on gcc.gnu.org [\#406](https://github.com/ueokande/vim-vixen/issues/406)
+- Avoid switching tab when following links in new tabs [\#403](https://github.com/ueokande/vim-vixen/issues/403)
+- Prev/next tab key bindings don't work until page is loaded [\#379](https://github.com/ueokande/vim-vixen/issues/379)
+- implement :q to close tab [\#260](https://github.com/ueokande/vim-vixen/issues/260)
+- Does not work in local web pages [\#92](https://github.com/ueokande/vim-vixen/issues/92)
+
+**Merged pull requests:**
+
+- Release 0.15 [\#421](https://github.com/ueokande/vim-vixen/pull/421) ([ueokande](https://github.com/ueokande))
+- Update README.md [\#418](https://github.com/ueokande/vim-vixen/pull/418) ([AlexeySachkov](https://github.com/AlexeySachkov))
+- Use await/async on e2e test [\#417](https://github.com/ueokande/vim-vixen/pull/417) ([ueokande](https://github.com/ueokande))
+- QA 0.15 [\#416](https://github.com/ueokande/vim-vixen/pull/416) ([ueokande](https://github.com/ueokande))
+- Fix no previous search keywords [\#415](https://github.com/ueokande/vim-vixen/pull/415) ([ueokande](https://github.com/ueokande))
+- Show error if not previous keywords [\#414](https://github.com/ueokande/vim-vixen/pull/414) ([ueokande](https://github.com/ueokande))
+- Reopen current window [\#413](https://github.com/ueokande/vim-vixen/pull/413) ([ueokande](https://github.com/ueokande))
+- Update node version [\#412](https://github.com/ueokande/vim-vixen/pull/412) ([ueokande](https://github.com/ueokande))
+- Update firefox version [\#411](https://github.com/ueokande/vim-vixen/pull/411) ([ueokande](https://github.com/ueokande))
+- Update webpack-cli to the 3.0.7 [\#410](https://github.com/ueokande/vim-vixen/pull/410) ([ueokande](https://github.com/ueokande))
+- Ignore case tab filtering [\#405](https://github.com/ueokande/vim-vixen/pull/405) ([ueokande](https://github.com/ueokande))
+- add follow link in tab to doc [\#350](https://github.com/ueokande/vim-vixen/pull/350) ([tevio](https://github.com/tevio))
+
+## [0.14](https://github.com/ueokande/vim-vixen/tree/0.14) (2018-05-17)
+
+**Merged pull requests:**
+
+- Release 0.14 [\#397](https://github.com/ueokande/vim-vixen/pull/397) ([ueokande](https://github.com/ueokande))
+
+## [0.13](https://github.com/ueokande/vim-vixen/tree/0.13) (2018-05-16)
+
+**Implemented enhancements:**
+
+- Option to open tabs from follow in the background [\#60](https://github.com/ueokande/vim-vixen/issues/60)
+- Shortcut to View Page Source [\#279](https://github.com/ueokande/vim-vixen/issues/279)
+- Feature-request: Cannot create bookmark? [\#165](https://github.com/ueokande/vim-vixen/issues/165)
+- Display when vim-vixen is disable [\#155](https://github.com/ueokande/vim-vixen/issues/155)
+- Cannot open bookmark by keyword [\#145](https://github.com/ueokande/vim-vixen/issues/145)
+- Delete tabs by keywords [\#55](https://github.com/ueokande/vim-vixen/issues/55)
+
+**Closed issues:**
+
+- ServiceNow web application does not display when Vim-Vixen is enabled  [\#373](https://github.com/ueokande/vim-vixen/issues/373)
+- iframe gets blocked and shows up as weird block on https://accounts.firefox.com [\#369](https://github.com/ueokande/vim-vixen/issues/369)
+- Case insensitive :buffer [\#367](https://github.com/ueokande/vim-vixen/issues/367)
+
+**Merged pull requests:**
+
+- Release 0.13 [\#395](https://github.com/ueokande/vim-vixen/pull/395) ([ueokande](https://github.com/ueokande))
+- QA 0.13 [\#394](https://github.com/ueokande/vim-vixen/pull/394) ([ueokande](https://github.com/ueokande))
+- Update packages [\#393](https://github.com/ueokande/vim-vixen/pull/393) ([ueokande](https://github.com/ueokande))
+- Add e2e test cases [\#392](https://github.com/ueokande/vim-vixen/pull/392) ([ueokande](https://github.com/ueokande))
+- Delete tabs [\#391](https://github.com/ueokande/vim-vixen/pull/391) ([ueokande](https://github.com/ueokande))
+- change "Plane" to "Plain" in settings page [\#389](https://github.com/ueokande/vim-vixen/pull/389) ([ghost](https://github.com/ghost))
+- addbookmark command [\#388](https://github.com/ueokande/vim-vixen/pull/388) ([ueokande](https://github.com/ueokande))
+- Open URLs from bookmarks [\#387](https://github.com/ueokande/vim-vixen/pull/387) ([ueokande](https://github.com/ueokande))
+- Addon enabled indicator [\#386](https://github.com/ueokande/vim-vixen/pull/386) ([ueokande](https://github.com/ueokande))
+- Update notification [\#385](https://github.com/ueokande/vim-vixen/pull/385) ([ueokande](https://github.com/ueokande))
+- Clean test [\#384](https://github.com/ueokande/vim-vixen/pull/384) ([ueokande](https://github.com/ueokande))
+- Update dependencies to enable Greenkeeper 🌴 [\#382](https://github.com/ueokande/vim-vixen/pull/382) ([greenkeeper[bot]](https://github.com/apps/greenkeeper))
+- Add shortcut to view page source [\#368](https://github.com/ueokande/vim-vixen/pull/368) ([emlow](https://github.com/emlow))
+- update build status badge [\#360](https://github.com/ueokande/vim-vixen/pull/360) ([ueokande](https://github.com/ueokande))
+- Migrate to CircleCI [\#359](https://github.com/ueokande/vim-vixen/pull/359) ([ueokande](https://github.com/ueokande))
+- Improve build [\#358](https://github.com/ueokande/vim-vixen/pull/358) ([ueokande](https://github.com/ueokande))
+- implement :q to close tab [\#348](https://github.com/ueokande/vim-vixen/pull/348) ([luanpotter](https://github.com/luanpotter))
+- Add vimperator-like keybindings for next and previous tabs [\#198](https://github.com/ueokande/vim-vixen/pull/198) ([kleschenko](https://github.com/kleschenko))
+- Open adjacent tabs and background tabs [\#171](https://github.com/ueokande/vim-vixen/pull/171) ([idlewan](https://github.com/idlewan))
+
+## [0.12](https://github.com/ueokande/vim-vixen/tree/0.12) (2018-03-09)
+
+**Implemented enhancements:**
+
+- Paste URL [\#3](https://github.com/ueokande/vim-vixen/issues/3)
+- Find mode does not remember search across pages [\#218](https://github.com/ueokande/vim-vixen/issues/218)
+
+**Fixed bugs:**
+
+- Search is contained for a single tab [\#285](https://github.com/ueokande/vim-vixen/issues/285)
+- Console bar remains after "yanking" [\#157](https://github.com/ueokande/vim-vixen/issues/157)
+
+**Closed issues:**
+
+- Option to prevent autojumping to the tab in case of 'F' [\#353](https://github.com/ueokande/vim-vixen/issues/353)
+- Allow remapping keys [\#349](https://github.com/ueokande/vim-vixen/issues/349)
+- Support for containers [\#341](https://github.com/ueokande/vim-vixen/issues/341)
+- 'f' keypress causes youtube player fullscreen [\#340](https://github.com/ueokande/vim-vixen/issues/340)
+- Can we add a shortcut for going back to the previous tab? [\#335](https://github.com/ueokande/vim-vixen/issues/335)
+- Created an AUR package [\#328](https://github.com/ueokande/vim-vixen/issues/328)
+- Is it possible to choose items from buffer/history [\#327](https://github.com/ueokande/vim-vixen/issues/327)
+- Feature: Hover \(for menus, images, etc\) [\#322](https://github.com/ueokande/vim-vixen/issues/322)
+- add `Ctrl-\[` alternative to `Esc` [\#273](https://github.com/ueokande/vim-vixen/issues/273)
+- Link opened in new tab should become child tab in Tree Style Tab [\#284](https://github.com/ueokande/vim-vixen/issues/284)
+- How to map Ctrl+\[ to escape [\#184](https://github.com/ueokande/vim-vixen/issues/184)
+
+**Merged pull requests:**
+
+- Release 0.12 [\#357](https://github.com/ueokande/vim-vixen/pull/357) ([ueokande](https://github.com/ueokande))
+- QA 0.12 [\#356](https://github.com/ueokande/vim-vixen/pull/356) ([ueokande](https://github.com/ueokande))
+- Search across pages [\#355](https://github.com/ueokande/vim-vixen/pull/355) ([ueokande](https://github.com/ueokande))
+- Hide console [\#354](https://github.com/ueokande/vim-vixen/pull/354) ([ueokande](https://github.com/ueokande))
+- Cancel by ctrl left bracket [\#351](https://github.com/ueokande/vim-vixen/pull/351) ([ueokande](https://github.com/ueokande))
+- Set opener tab id [\#347](https://github.com/ueokande/vim-vixen/pull/347) ([ueokande](https://github.com/ueokande))
+- add zomm tests [\#346](https://github.com/ueokande/vim-vixen/pull/346) ([ueokande](https://github.com/ueokande))
+- add e2e test cases [\#345](https://github.com/ueokande/vim-vixen/pull/345) ([ueokande](https://github.com/ueokande))
+- e2e scroll test [\#337](https://github.com/ueokande/vim-vixen/pull/337) ([ueokande](https://github.com/ueokande))
+- fixed grammar for warning prompt [\#332](https://github.com/ueokande/vim-vixen/pull/332) ([RyanWarnock](https://github.com/RyanWarnock))
+- End-to-End testing [\#329](https://github.com/ueokande/vim-vixen/pull/329) ([ueokande](https://github.com/ueokande))
+
+## [0.11](https://github.com/ueokande/vim-vixen/tree/0.11) (2018-01-23)
+
+**Closed issues:**
+
+- Unresponsive to any keyboard shortuts [\#319](https://github.com/ueokande/vim-vixen/issues/319)
+- Just stopped working \(firefox-nightly\) [\#318](https://github.com/ueokande/vim-vixen/issues/318)
+
+**Merged pull requests:**
+
+- Update packages [\#381](https://github.com/ueokande/vim-vixen/pull/381) ([ueokande](https://github.com/ueokande))
+- Release 0.11 [\#321](https://github.com/ueokande/vim-vixen/pull/321) ([ueokande](https://github.com/ueokande))
+- set default properties [\#320](https://github.com/ueokande/vim-vixen/pull/320) ([ueokande](https://github.com/ueokande))
+
+## [0.10](https://github.com/ueokande/vim-vixen/tree/0.10) (2018-01-20)
+
+**Merged pull requests:**
+
+- Release 0.10 [\#316](https://github.com/ueokande/vim-vixen/pull/316) ([ueokande](https://github.com/ueokande))
+
+## [0.9](https://github.com/ueokande/vim-vixen/tree/0.9) (2018-01-20)
+
+**Implemented enhancements:**
+
+- Feature-request: Add binding for going back to the most recently used tab [\#164](https://github.com/ueokande/vim-vixen/issues/164)
+- Feature request: focus on first input element using gi [\#153](https://github.com/ueokande/vim-vixen/issues/153)
+- Follow link from text content [\#147](https://github.com/ueokande/vim-vixen/issues/147)
+- Implement global marks [\#78](https://github.com/ueokande/vim-vixen/issues/78)
+- Configurable properties in settings [\#243](https://github.com/ueokande/vim-vixen/issues/243)
+- Implement "Focus Form Input" [\#98](https://github.com/ueokande/vim-vixen/issues/98)
+- Support custom characters for follow hints [\#58](https://github.com/ueokande/vim-vixen/issues/58)
+- Smooth scrolling option [\#57](https://github.com/ueokande/vim-vixen/issues/57)
+
+**Closed issues:**
+
+- List bookmarks in :open command [\#302](https://github.com/ueokande/vim-vixen/issues/302)
+- Console frame not hidden in fullscreen  [\#290](https://github.com/ueokande/vim-vixen/issues/290)
+- I have to wait for the page to be fully loader before switching tab [\#287](https://github.com/ueokande/vim-vixen/issues/287)
+- hint key [\#278](https://github.com/ueokande/vim-vixen/issues/278)
+- Console Frame Showing on Websites \(e.g. crates.io\) [\#270](https://github.com/ueokande/vim-vixen/issues/270)
+- Tab Search [\#261](https://github.com/ueokande/vim-vixen/issues/261)
+
+**Merged pull requests:**
+
+- Release 0.9 [\#315](https://github.com/ueokande/vim-vixen/pull/315) ([ueokande](https://github.com/ueokande))
+- QA 0.9 [\#314](https://github.com/ueokande/vim-vixen/pull/314) ([ueokande](https://github.com/ueokande))
+- keymaps-form: fix a typo [\#312](https://github.com/ueokande/vim-vixen/pull/312) ([mathstuf](https://github.com/mathstuf))
+- Default properties [\#309](https://github.com/ueokande/vim-vixen/pull/309) ([ueokande](https://github.com/ueokande))
+- Focus input [\#308](https://github.com/ueokande/vim-vixen/pull/308) ([ueokande](https://github.com/ueokande))
+- Properties support [\#303](https://github.com/ueokande/vim-vixen/pull/303) ([ueokande](https://github.com/ueokande))
+- Zip archive [\#301](https://github.com/ueokande/vim-vixen/pull/301) ([ueokande](https://github.com/ueokande))
+- Smooth scroll [\#307](https://github.com/ueokande/vim-vixen/pull/307) ([ueokande](https://github.com/ueokande))
+- support custom chars as hintchars [\#306](https://github.com/ueokande/vim-vixen/pull/306) ([ueokande](https://github.com/ueokande))
+- open clipboard's URL in current/new tab [\#300](https://github.com/ueokande/vim-vixen/pull/300) ([usk](https://github.com/usk))
+- Closing pinned tabs must be forced [\#236](https://github.com/ueokande/vim-vixen/pull/236) ([r3r57](https://github.com/r3r57))
+- Most recently used tab selector [\#137](https://github.com/ueokande/vim-vixen/pull/137) ([alx741](https://github.com/alx741))
+
+## [0.8](https://github.com/ueokande/vim-vixen/tree/0.8) (2017-12-30)
+
+**Implemented enhancements:**
+
+- Enable https://david-dm.org/ for project [\#118](https://github.com/ueokande/vim-vixen/issues/118)
+
+**Fixed bugs:**
+
+- URL suggestions \(history, bookmarks\) seems reverse order [\#188](https://github.com/ueokande/vim-vixen/issues/188)
+
+**Closed issues:**
+
+- Add option to not switching to new tab with follow.start [\#282](https://github.com/ueokande/vim-vixen/issues/282)
+- dark theme for console [\#272](https://github.com/ueokande/vim-vixen/issues/272)
+- Request: support search bookmarks [\#269](https://github.com/ueokande/vim-vixen/issues/269)
+- google search in command line replaces + with whitespace [\#256](https://github.com/ueokande/vim-vixen/issues/256)
+- Everything starting from a '\#' character when opening a page is ignored [\#244](https://github.com/ueokande/vim-vixen/issues/244)
+
+**Merged pull requests:**
+
+- Bump a version [\#295](https://github.com/ueokande/vim-vixen/pull/295) ([ueokande](https://github.com/ueokande))
+- QA 0.8 [\#294](https://github.com/ueokande/vim-vixen/pull/294) ([ueokande](https://github.com/ueokande))
+- fix scroll settings typos [\#293](https://github.com/ueokande/vim-vixen/pull/293) ([l4rzy](https://github.com/l4rzy))
+- do not follow link which has aria-hidden attribute or aria-disabled a… [\#291](https://github.com/ueokande/vim-vixen/pull/291) ([usk](https://github.com/usk))
+- Fix typo [\#280](https://github.com/ueokande/vim-vixen/pull/280) ([c01o](https://github.com/c01o))
+- Fix grammar: histories -\> history [\#274](https://github.com/ueokande/vim-vixen/pull/274) ([YourFin](https://github.com/YourFin))
+- david-dm.org [\#263](https://github.com/ueokande/vim-vixen/pull/263) ([ueokande](https://github.com/ueokande))
+- Use encodeURIComponent for search queries [\#252](https://github.com/ueokande/vim-vixen/pull/252) ([ollef](https://github.com/ollef))
+- Pagination tweaks and fixes [\#240](https://github.com/ueokande/vim-vixen/pull/240) ([chocolateboy](https://github.com/chocolateboy))
+- Fix history completion to show most frequent results first. [\#221](https://github.com/ueokande/vim-vixen/pull/221) ([kleschenko](https://github.com/kleschenko))
+- Fix buffers completion when there are some tabs with undefined title. [\#222](https://github.com/ueokande/vim-vixen/pull/222) ([kleschenko](https://github.com/kleschenko))
+
+## [0.7](https://github.com/ueokande/vim-vixen/tree/0.7) (2017-11-28)
+
+**Implemented enhancements:**
+
+- Add a yanking variant of the follow mode [\#201](https://github.com/ueokande/vim-vixen/issues/201)
+- GUI settings [\#26](https://github.com/ueokande/vim-vixen/issues/26)
+
+**Fixed bugs:**
+
+- Pressing f while searching triggers the follow-link keymap [\#151](https://github.com/ueokande/vim-vixen/issues/151)
+
+**Closed issues:**
+
+- Feature Request: :open \[search through bookmarks instead of history\] [\#255](https://github.com/ueokande/vim-vixen/issues/255)
+- Selectively enable/disable binds on blacklisted sites. [\#245](https://github.com/ueokande/vim-vixen/issues/245)
+- autocomplete when opening a new url? [\#237](https://github.com/ueokande/vim-vixen/issues/237)
+- Can not follow links on some pages [\#234](https://github.com/ueokande/vim-vixen/issues/234)
+- Request :split :vsplit \(tile type window manager\) [\#231](https://github.com/ueokande/vim-vixen/issues/231)
+- Bug: Searching tabs in buffer doesn't work [\#227](https://github.com/ueokande/vim-vixen/issues/227)
+- Find bar is sometimes hidden behind popup URL/status at bottom of screen [\#226](https://github.com/ueokande/vim-vixen/issues/226)
+- Next item keybinding in console conflicts with new window  [\#223](https://github.com/ueokande/vim-vixen/issues/223)
+- "about:config" considered as illegal URL [\#217](https://github.com/ueokande/vim-vixen/issues/217)
+- Command bar not correctly visible if URL text is shown [\#215](https://github.com/ueokande/vim-vixen/issues/215)
+- Slow response in console \(open/tabopen/etc.\) as you search [\#214](https://github.com/ueokande/vim-vixen/issues/214)
+- GITTER IS AVAILABLE [\#210](https://github.com/ueokande/vim-vixen/issues/210)
+- follow-start option: add background tabs [\#197](https://github.com/ueokande/vim-vixen/issues/197)
+
+**Merged pull requests:**
+
+- Release 0.7 [\#259](https://github.com/ueokande/vim-vixen/pull/259) ([ueokande](https://github.com/ueokande))
+- QA 0.7 [\#253](https://github.com/ueokande/vim-vixen/pull/253) ([ueokande](https://github.com/ueokande))
+- GUI Settings [\#248](https://github.com/ueokande/vim-vixen/pull/248) ([ueokande](https://github.com/ueokande))
+- Add badges to READM [\#246](https://github.com/ueokande/vim-vixen/pull/246) ([ueokande](https://github.com/ueokande))
+
+## [0.6](https://github.com/ueokande/vim-vixen/tree/0.6) (2017-11-19)
+
+**Implemented enhancements:**
+
+- Show Bookmarks in :open and :tabopen [\#186](https://github.com/ueokande/vim-vixen/issues/186)
+- Add c-n, c-j, c-p, c-k, c-m to console keybind [\#162](https://github.com/ueokande/vim-vixen/pull/162) ([heavenshell](https://github.com/heavenshell))
+
+**Fixed bugs:**
+
+- vim-vixen does not work with etherpad [\#173](https://github.com/ueokande/vim-vixen/issues/173)
+- Allow alt+d \(select URL bar\) to work with d for delete-tab [\#138](https://github.com/ueokande/vim-vixen/issues/138)
+- Console frame not hidden in fullscreen [\#154](https://github.com/ueokande/vim-vixen/issues/154)
+- Does not work on all pages? [\#139](https://github.com/ueokande/vim-vixen/issues/139)
+- http://pitchify.com styling broken by vim vixen [\#127](https://github.com/ueokande/vim-vixen/issues/127)
+
+**Closed issues:**
+
+- Incompatibility when viewing certain website - a grey screen is displayed blocking the webpage [\#209](https://github.com/ueokande/vim-vixen/issues/209)
+- Focusing on inner scrollbox on page [\#194](https://github.com/ueokande/vim-vixen/issues/194)
+- navigating to next and previous links in posts [\#193](https://github.com/ueokande/vim-vixen/issues/193)
+- request: gu to navigate to parent url path [\#192](https://github.com/ueokande/vim-vixen/issues/192)
+- ctrl+6/ctrl+^ to switch to the last used tab [\#191](https://github.com/ueokande/vim-vixen/issues/191)
+- Blacklisting localhost [\#187](https://github.com/ueokande/vim-vixen/issues/187)
+- Bind JavaScript code for key [\#185](https://github.com/ueokande/vim-vixen/issues/185)
+- Can't open about:config and about:addons [\#179](https://github.com/ueokande/vim-vixen/issues/179)
+- enabling vim-vixen blanks https://postgresweekly.com/ [\#170](https://github.com/ueokande/vim-vixen/issues/170)
+- Reader Mode [\#70](https://github.com/ueokande/vim-vixen/issues/70)
+
+**Merged pull requests:**
+
+- Bump a version [\#212](https://github.com/ueokande/vim-vixen/pull/212) ([ueokande](https://github.com/ueokande))
+- QA 0.6 [\#211](https://github.com/ueokande/vim-vixen/pull/211) ([ueokande](https://github.com/ueokande))
+- improve \#linkPrev and \#linkNext [\#196](https://github.com/ueokande/vim-vixen/pull/196) ([chocolateboy](https://github.com/chocolateboy))
+- Fix for certain pages [\#160](https://github.com/ueokande/vim-vixen/pull/160) ([ueokande](https://github.com/ueokande))
+- add support for following some buttons on mobile.twitter.com [\#133](https://github.com/ueokande/vim-vixen/pull/133) ([usk](https://github.com/usk))
+
+## [0.5](https://github.com/ueokande/vim-vixen/tree/0.5) (2017-11-13)
+
+**Implemented enhancements:**
+
+- Page search with `/` [\#1](https://github.com/ueokande/vim-vixen/issues/1)
+
+**Fixed bugs:**
+
+- 'f' key conflicts with 'cmd + f' search function [\#88](https://github.com/ueokande/vim-vixen/issues/88)
+
+**Closed issues:**
+
+- cannot save JSON configuration [\#143](https://github.com/ueokande/vim-vixen/issues/143)
+- Ubuntu Launchpad.net login broken with Vim Vixen enabled [\#140](https://github.com/ueokande/vim-vixen/issues/140)
+
+**Merged pull requests:**
+
+- Release 0.5 [\#152](https://github.com/ueokande/vim-vixen/pull/152) ([ueokande](https://github.com/ueokande))
+- QA 0.5 [\#150](https://github.com/ueokande/vim-vixen/pull/150) ([ueokande](https://github.com/ueokande))
+- support about blank [\#149](https://github.com/ueokande/vim-vixen/pull/149) ([ueokande](https://github.com/ueokande))
+- \[WIP\] Find mode [\#142](https://github.com/ueokande/vim-vixen/pull/142) ([ueokande](https://github.com/ueokande))
+- Meta keys [\#132](https://github.com/ueokande/vim-vixen/pull/132) ([ueokande](https://github.com/ueokande))
+- add support for duplicating current tab [\#131](https://github.com/ueokande/vim-vixen/pull/131) ([usk](https://github.com/usk))
+- added support for pinning/unpinning tabs [\#124](https://github.com/ueokande/vim-vixen/pull/124) ([JiaboHou](https://github.com/JiaboHou))
+- Add Tabs first/last selectors [\#113](https://github.com/ueokande/vim-vixen/pull/113) ([alx741](https://github.com/alx741))
+
+## [0.4](https://github.com/ueokande/vim-vixen/tree/0.4) (2017-11-05)
+
+**Implemented enhancements:**
+
+- Run plugin at page opened [\#83](https://github.com/ueokande/vim-vixen/issues/83)
+
+**Fixed bugs:**
+
+- Cannot search on page [\#91](https://github.com/ueokande/vim-vixen/issues/91)
+- Scrolling does not work on Hacker News [\#107](https://github.com/ueokande/vim-vixen/issues/107)
+- Plugin is inert after an upgrade [\#80](https://github.com/ueokande/vim-vixen/issues/80)
+- No way to navigate the completion list without poluting the query. [\#69](https://github.com/ueokande/vim-vixen/issues/69)
+- Follow does not highlight \<area\> tag links [\#64](https://github.com/ueokande/vim-vixen/issues/64)
+
+**Closed issues:**
+
+- Page scrolling doesn't work on https://news.ycombinator.com [\#128](https://github.com/ueokande/vim-vixen/issues/128)
+- Navigation/scrolling not working on some sites [\#122](https://github.com/ueokande/vim-vixen/issues/122)
+- Flickering like issue [\#103](https://github.com/ueokande/vim-vixen/issues/103)
+- Restart command [\#100](https://github.com/ueokande/vim-vixen/issues/100)
+
+**Merged pull requests:**
+
+- Release 0.4 [\#136](https://github.com/ueokande/vim-vixen/pull/136) ([ueokande](https://github.com/ueokande))
+- fix settings reload on content [\#135](https://github.com/ueokande/vim-vixen/pull/135) ([ueokande](https://github.com/ueokande))
+- QA 0.4 [\#134](https://github.com/ueokande/vim-vixen/pull/134) ([ueokande](https://github.com/ueokande))
+- fix plugin load [\#129](https://github.com/ueokande/vim-vixen/pull/129) ([ueokande](https://github.com/ueokande))
+- fix completion navigate [\#126](https://github.com/ueokande/vim-vixen/pull/126) ([ueokande](https://github.com/ueokande))
+- follow area tags [\#123](https://github.com/ueokande/vim-vixen/pull/123) ([ueokande](https://github.com/ueokande))
+- Minor adjustments in readme for clarification [\#120](https://github.com/ueokande/vim-vixen/pull/120) ([sunflowerseastar](https://github.com/sunflowerseastar))
+- Bring Firefox current inTravis [\#117](https://github.com/ueokande/vim-vixen/pull/117) ([gliptak](https://github.com/gliptak))
+- Readme typos [\#112](https://github.com/ueokande/vim-vixen/pull/112) ([alx741](https://github.com/alx741))
+- scroll html and body preferentially [\#110](https://github.com/ueokande/vim-vixen/pull/110) ([ueokande](https://github.com/ueokande))
+- run at document end and run in all urls [\#104](https://github.com/ueokande/vim-vixen/pull/104) ([ueokande](https://github.com/ueokande))
+- blacklist in README [\#97](https://github.com/ueokande/vim-vixen/pull/97) ([ueokande](https://github.com/ueokande))
+
+## [0.3](https://github.com/ueokande/vim-vixen/tree/0.3) (2017-10-26)
+
+**Implemented enhancements:**
+
+- "n" and "N" do not search for next match [\#76](https://github.com/ueokande/vim-vixen/issues/76)
+- URL blacklist to disable plugin [\#11](https://github.com/ueokande/vim-vixen/issues/11)
+- Disable temporarily [\#10](https://github.com/ueokande/vim-vixen/issues/10)
+
+**Fixed bugs:**
+
+- "/" key bind config missing [\#74](https://github.com/ueokande/vim-vixen/issues/74)
+- poor integration with gmail [\#89](https://github.com/ueokande/vim-vixen/issues/89)
+- Pop-up windows are prevented [\#82](https://github.com/ueokande/vim-vixen/issues/82)
+- Ignore gmail input [\#63](https://github.com/ueokande/vim-vixen/issues/63)
+- Lose focus from content [\#14](https://github.com/ueokande/vim-vixen/issues/14)
+
+**Closed issues:**
+
+- Domain/Page exclusion/disable [\#87](https://github.com/ueokande/vim-vixen/issues/87)
+
+**Merged pull requests:**
+
+- Testing for 0.3 [\#96](https://github.com/ueokande/vim-vixen/pull/96) ([ueokande](https://github.com/ueokande))
+- Release 0.3 [\#95](https://github.com/ueokande/vim-vixen/pull/95) ([ueokande](https://github.com/ueokande))
+- target='\_blank' link [\#94](https://github.com/ueokande/vim-vixen/pull/94) ([ueokande](https://github.com/ueokande))
+- Improve for aberration pages [\#93](https://github.com/ueokande/vim-vixen/pull/93) ([ueokande](https://github.com/ueokande))
+- URL blacklist [\#90](https://github.com/ueokande/vim-vixen/pull/90) ([ueokande](https://github.com/ueokande))
+- Disable add-on temporary [\#86](https://github.com/ueokande/vim-vixen/pull/86) ([ueokande](https://github.com/ueokande))
+- Use \<kbd\> tags [\#85](https://github.com/ueokande/vim-vixen/pull/85) ([ueokande](https://github.com/ueokande))
+- Fix close focus [\#84](https://github.com/ueokande/vim-vixen/pull/84) ([ueokande](https://github.com/ueokande))
+
+## [0.2](https://github.com/ueokande/vim-vixen/tree/0.2) (2017-10-18)
+
+**Implemented enhancements:**
+
+- Make it possible to disable extension for a particular URL pattern [\#67](https://github.com/ueokande/vim-vixen/issues/67)
+
+**Fixed bugs:**
+
+- Suggestions are not shown after closed console [\#65](https://github.com/ueokande/vim-vixen/issues/65)
+- VIm Vixen events are fired on Slack and Twitter [\#53](https://github.com/ueokande/vim-vixen/issues/53)
+- Follow does not work in iframe [\#21](https://github.com/ueokande/vim-vixen/issues/21)
+
+**Closed issues:**
+
+- Commands unexpectedly captured in text editing [\#79](https://github.com/ueokande/vim-vixen/issues/79)
+
+**Merged pull requests:**
+
+- Update QA [\#75](https://github.com/ueokande/vim-vixen/pull/75) ([ueokande](https://github.com/ueokande))
+- some fix [\#73](https://github.com/ueokande/vim-vixen/pull/73) ([ueokande](https://github.com/ueokande))
+- Fix empty suggestions [\#72](https://github.com/ueokande/vim-vixen/pull/72) ([ueokande](https://github.com/ueokande))
+- Multi frame following [\#61](https://github.com/ueokande/vim-vixen/pull/61) ([ueokande](https://github.com/ueokande))
+- Fix 53 [\#54](https://github.com/ueokande/vim-vixen/pull/54) ([ueokande](https://github.com/ueokande))
+- Fix typo [\#52](https://github.com/ueokande/vim-vixen/pull/52) ([CYBAI](https://github.com/CYBAI))
+- Release 0.2 [\#71](https://github.com/ueokande/vim-vixen/pull/71) ([ueokande](https://github.com/ueokande))
+
+## [0.1](https://github.com/ueokande/vim-vixen/tree/0.1) (2017-10-11)
+
+**Implemented enhancements:**
+
+- New window command [\#5](https://github.com/ueokande/vim-vixen/issues/5)
+- Yank URL [\#2](https://github.com/ueokande/vim-vixen/issues/2)
+- Open search engine's page with empty keywords [\#31](https://github.com/ueokande/vim-vixen/issues/31)
+
+**Fixed bugs:**
+
+- Key-repeat does not work [\#17](https://github.com/ueokande/vim-vixen/issues/17)
+- Browser's short-cuts are not ignored. [\#15](https://github.com/ueokande/vim-vixen/issues/15)
+- Typed characters lack in console on fast typing [\#13](https://github.com/ueokande/vim-vixen/issues/13)
+- Not work on some pages [\#12](https://github.com/ueokande/vim-vixen/issues/12)
+- Start follows for new tabs [\#48](https://github.com/ueokande/vim-vixen/issues/48)
+- buffer command with number does not work with big number [\#42](https://github.com/ueokande/vim-vixen/issues/42)
+- Typed "buffer" show and error "No matching buffer for buffer" [\#41](https://github.com/ueokande/vim-vixen/issues/41)
+- only "open" command opens search results for keyword "open" [\#40](https://github.com/ueokande/vim-vixen/issues/40)
+- Blank commands show error "command is not defined" [\#39](https://github.com/ueokande/vim-vixen/issues/39)
+- `gU` does not work  [\#38](https://github.com/ueokande/vim-vixen/issues/38)
+- Error occors to select prev to first tab [\#37](https://github.com/ueokande/vim-vixen/issues/37)
+- \<C-E\>/\<C-Y\> is reversed [\#36](https://github.com/ueokande/vim-vixen/issues/36)
+
+**Closed issues:**
+
+- Issue or pull request template [\#8](https://github.com/ueokande/vim-vixen/issues/8)
+- Contributing [\#7](https://github.com/ueokande/vim-vixen/issues/7)
+- Code of conduct [\#6](https://github.com/ueokande/vim-vixen/issues/6)
+
+**Merged pull requests:**
+
+- follow link in new tab [\#51](https://github.com/ueokande/vim-vixen/pull/51) ([ueokande](https://github.com/ueokande))
+- fix buffer commands [\#50](https://github.com/ueokande/vim-vixen/pull/50) ([ueokande](https://github.com/ueokande))
+- Fix console tokenizer [\#49](https://github.com/ueokande/vim-vixen/pull/49) ([ueokande](https://github.com/ueokande))
+- Fix source map [\#47](https://github.com/ueokande/vim-vixen/pull/47) ([ueokande](https://github.com/ueokande))
+- Ignore meta keys on input [\#45](https://github.com/ueokande/vim-vixen/pull/45) ([ueokande](https://github.com/ueokande))
+- Fix tab selection [\#44](https://github.com/ueokande/vim-vixen/pull/44) ([ueokande](https://github.com/ueokande))
+- Fix default keymap [\#43](https://github.com/ueokande/vim-vixen/pull/43) ([ueokande](https://github.com/ueokande))
+- Build package [\#32](https://github.com/ueokande/vim-vixen/pull/32) ([ueokande](https://github.com/ueokande))
+- README [\#30](https://github.com/ueokande/vim-vixen/pull/30) ([ueokande](https://github.com/ueokande))
+- fix operation name [\#29](https://github.com/ueokande/vim-vixen/pull/29) ([ueokande](https://github.com/ueokande))
+- Horizonal scroll [\#28](https://github.com/ueokande/vim-vixen/pull/28) ([ueokande](https://github.com/ueokande))
+- Use React in settings [\#27](https://github.com/ueokande/vim-vixen/pull/27) ([ueokande](https://github.com/ueokande))
+- Add GitHub meta files [\#25](https://github.com/ueokande/vim-vixen/pull/25) ([ueokande](https://github.com/ueokande))
+- Yank url [\#24](https://github.com/ueokande/vim-vixen/pull/24) ([ueokande](https://github.com/ueokande))
+- winopen command [\#23](https://github.com/ueokande/vim-vixen/pull/23) ([ueokande](https://github.com/ueokande))
+- Refactor: Separate domains [\#22](https://github.com/ueokande/vim-vixen/pull/22) ([ueokande](https://github.com/ueokande))
+- Prevent page keymaps [\#20](https://github.com/ueokande/vim-vixen/pull/20) ([ueokande](https://github.com/ueokande))
+- Refactor: full redux on content and background [\#19](https://github.com/ueokande/vim-vixen/pull/19) ([ueokande](https://github.com/ueokande))
+- Fix key-repeat does not work [\#18](https://github.com/ueokande/vim-vixen/pull/18) ([ueokande](https://github.com/ueokande))
+- Enable keys on github.com [\#16](https://github.com/ueokande/vim-vixen/pull/16) ([ueokande](https://github.com/ueokande))
+- Fix errors on tabs selection [\#46](https://github.com/ueokande/vim-vixen/pull/46) ([ueokande](https://github.com/ueokande))
+- Release 0.1 [\#35](https://github.com/ueokande/vim-vixen/pull/35) ([ueokande](https://github.com/ueokande))
+- QA [\#33](https://github.com/ueokande/vim-vixen/pull/33) ([ueokande](https://github.com/ueokande))
+
+## [initial-project](https://github.com/ueokande/vim-vixen/tree/initial-project) (2017-09-09)
+
+- initial release


### PR DESCRIPTION
This PR adds a [changelog](https://keepachangelog.com/en/1.0.0/) generated with [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator):

```
$ github_changelog_generator     \
    --header-label "# Changelog" \
    --token <token>              \
    ueokande/vim-vixen
```

It can easily be (re)generated automatically and cleaned up with a bit of scripting.