### PR TITLE
Handle errors on loading settings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,7 @@
     "function-paren-newline": "off",
     "id-length": "off",
     "indent": ["error", 2],
+    "init-declarations": "off",
     "jsx-quotes": ["error", "prefer-single"],
     "max-classes-per-file": "off",
     "max-lines": "off",

--- a/src/background/presenters/NotifyPresenter.ts
+++ b/src/background/presenters/NotifyPresenter.ts
@@ -1,39 +1,37 @@
 import { injectable } from 'tsyringe';
 
-const NOTIFICATION_ID = 'vimvixen-update';
+const NOTIFICATION_ID_UPDATE = 'vimvixen-update';
+const NOTIFICATION_ID_INVALID_SETTINGS = 'vimvixen-update-invalid-settings';
 
 @injectable()
 export default class NotifyPresenter {
   async notifyUpdated(version: string, onclick: () => void): Promise<void> {
     let title = `Vim Vixen ${version} has been installed`;
     let message = 'Click here to see release notes';
-    await this.notify(title, message, onclick);
-  }
 
-  async notifyInvalidSettings(onclick: () => void): Promise<void> {
-    let title = `Loaded settings is invalid`;
-    // eslint-disable-next-line max-len
-    let message = 'The default settings is used due to the last saved settings is invalid.  Check your current settings from the add-on preference';
-    await this.notify(title, message, onclick);
-  }
-
-  private async notify(
-    title: string,
-    message: string,
-    onclick: () => void,
-  ): Promise<void> {
     const listener = (id: string) => {
-      if (id !== NOTIFICATION_ID) {
+      if (id !== NOTIFICATION_ID_UPDATE) {
         return;
       }
-
       onclick();
-
       browser.notifications.onClicked.removeListener(listener);
     };
     browser.notifications.onClicked.addListener(listener);
 
-    await browser.notifications.create(NOTIFICATION_ID, {
+    await browser.notifications.create(NOTIFICATION_ID_UPDATE, {
+      'type': 'basic',
+      'iconUrl': browser.extension.getURL('resources/icon_48x48.png'),
+      title,
+      message,
+    });
+  }
+
+  async notifyInvalidSettings(): Promise<void> {
+    let title = `Loaded settings is invalid`;
+    // eslint-disable-next-line max-len
+    let message = 'The default settings is used due to the last saved settings is invalid.  Check your current settings from the add-on preference';
+
+    await browser.notifications.create(NOTIFICATION_ID_INVALID_SETTINGS, {
       'type': 'basic',
       'iconUrl': browser.extension.getURL('resources/icon_48x48.png'),
       title,

--- a/src/background/presenters/NotifyPresenter.ts
+++ b/src/background/presenters/NotifyPresenter.ts
@@ -4,7 +4,20 @@ const NOTIFICATION_ID = 'vimvixen-update';
 
 @injectable()
 export default class NotifyPresenter {
-  async notify(
+  async notifyUpdated(version: string, onclick: () => void): Promise<void> {
+    let title = `Vim Vixen ${version} has been installed`;
+    let message = 'Click here to see release notes';
+    await this.notify(title, message, onclick);
+  }
+
+  async notifyInvalidSettings(onclick: () => void): Promise<void> {
+    let title = `Loaded settings is invalid`;
+    // eslint-disable-next-line max-len
+    let message = 'The default settings is used due to the last saved settings is invalid.  Check your current settings from the add-on preference';
+    await this.notify(title, message, onclick);
+  }
+
+  private async notify(
     title: string,
     message: string,
     onclick: () => void,

--- a/src/background/usecases/SettingUseCase.ts
+++ b/src/background/usecases/SettingUseCase.ts
@@ -30,7 +30,7 @@ export default class SettingUseCase {
     try {
       value = data.toSettings();
     } catch (e) {
-      this.notifyPresenter.notifyInvalidSettings(() => {});
+      this.notifyPresenter.notifyInvalidSettings();
       value = DefaultSettingData.toSettings();
     }
     this.settingRepository.update(value!!);

--- a/src/background/usecases/SettingUseCase.ts
+++ b/src/background/usecases/SettingUseCase.ts
@@ -4,6 +4,7 @@ import PersistentSettingRepository
 import SettingRepository from '../repositories/SettingRepository';
 import { DefaultSettingData } from '../../shared/SettingData';
 import Settings from '../../shared/Settings';
+import NotifyPresenter from '../presenters/NotifyPresenter';
 
 @injectable()
 export default class SettingUseCase {
@@ -11,6 +12,7 @@ export default class SettingUseCase {
   constructor(
     private persistentSettingRepository: PersistentSettingRepository,
     private settingRepository: SettingRepository,
+    private notifyPresenter: NotifyPresenter,
   ) {
   }
 
@@ -24,8 +26,14 @@ export default class SettingUseCase {
       data = DefaultSettingData;
     }
 
-    let value = data.toSettings();
-    this.settingRepository.update(value);
+    let value: Settings;
+    try {
+      value = data.toSettings();
+    } catch (e) {
+      this.notifyPresenter.notifyInvalidSettings(() => {});
+      value = DefaultSettingData.toSettings();
+    }
+    this.settingRepository.update(value!!);
     return value;
   }
 }

--- a/src/background/usecases/VersionUseCase.ts
+++ b/src/background/usecases/VersionUseCase.ts
@@ -12,10 +12,8 @@ export default class VersionUseCase {
 
   notify(): Promise<void> {
     let manifest = browser.runtime.getManifest();
-    let title = `Vim Vixen ${manifest.version} has been installed`;
-    let message = 'Click here to see release notes';
     let url = this.releaseNoteUrl(manifest.version);
-    return this.notifyPresenter.notify(title, message, () => {
+    return this.notifyPresenter.notifyUpdated(manifest.version, () => {
       this.tabPresenter.create(url);
     });
   }


### PR DESCRIPTION
close #598 

The error on loading settings can occurs when the settings lose backward compatibility on version up, or the saved date is broken.  The error is caught, then the script done fallback to default settings and notify it to user.