### PR TITLE
Add :help command to show help page

### DIFF
--- a/e2e/command_help.test.ts
+++ b/e2e/command_help.test.ts
@@ -1,0 +1,49 @@
+import * as path from 'path';
+import * as assert from 'assert';
+
+import TestServer from './lib/TestServer';
+import eventually from './eventually';
+import { Builder, Lanthan } from 'lanthan';
+import { WebDriver } from 'selenium-webdriver';
+import Page from './lib/Page';
+
+describe("help command test", () => {
+  let server = new TestServer();
+  let lanthan: Lanthan;
+  let webdriver: WebDriver;
+  let browser: any;
+  let page: Page;
+
+  before(async() => {
+    lanthan = await Builder
+      .forBrowser('firefox')
+      .spyAddon(path.join(__dirname, '..'))
+      .build();
+    webdriver = lanthan.getWebDriver();
+    browser = lanthan.getWebExtBrowser();
+
+    await server.start();
+  });
+
+  after(async() => {
+    await server.stop();
+    if (lanthan) {
+      await lanthan.quit();
+    }
+  });
+
+  beforeEach(async() => {
+    page = await Page.navigateTo(webdriver, server.url());
+  })
+
+  it('should open help page by help command ', async() => {
+    let console = await page.showConsole();
+    await console.execCommand('help');
+
+    await eventually(async() => {
+      let tabs = await browser.tabs.query({ active: true });
+      assert.strictEqual(tabs[0].url, 'https://ueokande.github.io/vim-vixen/')
+    });
+  });
+});
+

--- a/e2e/completion.test.ts
+++ b/e2e/completion.test.ts
@@ -40,7 +40,7 @@ describe("general completion test", () => {
     let console = await page.showConsole();
 
     let items = await console.getCompletions();
-    assert.strictEqual(items.length, 10);
+    assert.strictEqual(items.length, 11);
     assert.deepStrictEqual(items[0], { type: 'title', text: 'Console Command' });
     assert.ok(items[1].text.startsWith('set'))
     assert.ok(items[2].text.startsWith('open'))

--- a/src/background/controllers/CommandController.ts
+++ b/src/background/controllers/CommandController.ts
@@ -96,6 +96,9 @@ export default class CommandController {
       return this.commandIndicator.quitAll();
     case 'set':
       return this.commandIndicator.set(keywords);
+    case 'h':
+    case 'help':
+      return this.commandIndicator.help();
     }
     throw new Error(words[0] + ' command is not defined');
   }

--- a/src/background/domains/CommandDocs.ts
+++ b/src/background/domains/CommandDocs.ts
@@ -8,4 +8,5 @@ export default {
   bdeletes: 'Close all tabs matched by keywords',
   quit: 'Close the current tab',
   quitall: 'Close all tabs',
+  help: 'Open Vim Vixen help in new tab',
 } as {[key: string]: string};

--- a/src/background/presenters/HelpPresenter.ts
+++ b/src/background/presenters/HelpPresenter.ts
@@ -1,0 +1,10 @@
+import { injectable } from 'tsyringe';
+
+const url = 'https://ueokande.github.io/vim-vixen/';
+
+@injectable()
+export default class HelpPresenter {
+  async open(): Promise<void> {
+    await browser.tabs.create({ url, active: true });
+  }
+}

--- a/src/background/usecases/CommandUseCase.ts
+++ b/src/background/usecases/CommandUseCase.ts
@@ -4,6 +4,7 @@ import * as parsers from './parsers';
 import * as urls from '../../shared/urls';
 import TabPresenter from '../presenters/TabPresenter';
 import WindowPresenter from '../presenters/WindowPresenter';
+import HelpPresenter from '../presenters/HelpPresenter';
 import SettingRepository from '../repositories/SettingRepository';
 import BookmarkRepository from '../repositories/BookmarkRepository';
 import ConsoleClient from '../infrastructures/ConsoleClient';
@@ -15,6 +16,7 @@ export default class CommandIndicator {
   constructor(
     private tabPresenter: TabPresenter,
     private windowPresenter: WindowPresenter,
+    private helpPresenter: HelpPresenter,
     private settingRepository: SettingRepository,
     private bookmarkRepository: BookmarkRepository,
     private consoleClient: ConsoleClient,
@@ -136,7 +138,11 @@ export default class CommandIndicator {
     return this.contentMessageClient.broadcastSettingsChanged();
   }
 
-  async urlOrSearch(keywords: string): Promise<any> {
+  help(): Promise<void> {
+    return this.helpPresenter.open();
+  }
+
+  private async urlOrSearch(keywords: string): Promise<any> {
     let settings = await this.settingRepository.get();
     return urls.searchUrl(keywords, settings.search);
   }


### PR DESCRIPTION
Close  #239

Add `:help` command to show help page of Vim Vixen.  By this command, Vim Vixen opens documents into the new tab.  The command does not support help page with a parameter (such as `:help commands`) not yet.