### PR TITLE
don't let pointer events be overidden

### DIFF
--- a/src/content/site-style.ts
+++ b/src/content/site-style.ts
@@ -10,7 +10,7 @@ export default `
   z-index: 2147483647;
   border: none;
   background-color: unset;
-  pointer-events:none;
+  pointer-events:none !important;
 }
 
 .vimvixen-hint {


### PR DESCRIPTION
if websites overrides vim-vixen consoles pointer-events it can make the site unusable.