### PR TITLE
Clear keys on window blur

### DIFF
--- a/src/content/Application.ts
+++ b/src/content/Application.ts
@@ -40,6 +40,7 @@ export default class Application {
 
   run() {
     this.routeCommonComponents();
+    this.routeFocusEvents();
     if (window.self === window.top) {
       this.routeMasterComponents();
     }
@@ -117,5 +118,11 @@ export default class Application {
     inputDriver.onKey(key => this.keymapController.press(key));
 
     this.settingController.initSettings();
+  }
+
+  private routeFocusEvents() {
+    window.addEventListener('blur', () => {
+      this.keymapController.onBlurWindow();
+    });
   }
 }

--- a/src/content/controllers/KeymapController.ts
+++ b/src/content/controllers/KeymapController.ts
@@ -99,4 +99,8 @@ export default class KeymapController {
     }
     return true;
   }
+
+  onBlurWindow() {
+    this.keymapUseCase.cancel();
+  }
 }

--- a/src/content/usecases/KeymapUseCase.ts
+++ b/src/content/usecases/KeymapUseCase.ts
@@ -70,6 +70,10 @@ export default class KeymapUseCase {
     return null;
   }
 
+  cancel() {
+    this.repository.clear();
+  }
+
   private keymapEntityMap(): [KeySequence, operations.Operation][] {
     const keymaps = this.settingRepository.get().keymaps.combine(reservedKeymaps);
     let entries = keymaps.entries().map(

--- a/src/shared/settings/Key.ts
+++ b/src/shared/settings/Key.ts
@@ -60,7 +60,7 @@ export default class Key {
   }
 
   isDigit(): boolean {
-    return digits.includes(this.key);
+    return digits.includes(this.key) && !this.ctrl && !this.alt && !this.meta;
   }
 
   equals(key: Key) {

--- a/test/shared/settings/Key.test.ts
+++ b/test/shared/settings/Key.test.ts
@@ -80,7 +80,7 @@ describe("Key", () => {
     it('returns true if the key is a digit', () => {
         expect(new Key({ key: '0' }).isDigit()).to.be.true;
       expect(new Key({ key: '9' }).isDigit()).to.be.true;
-      expect(new Key({ key: '9', shift: true }).isDigit()).to.be.true;
+      expect(new Key({ key: '9', alt: true }).isDigit()).to.be.false;
 
       expect(new Key({ key: 'a' }).isDigit()).to.be.false;
       expect(new Key({ key: '０' }).isDigit()).to.be.false;


### PR DESCRIPTION
The add-on treats digit keys with <kbd>Alt</kbd> are distinct from numeric prefix.  In addition, the key inputs are canceled on window blur.  This change fixes #693.