### PR TITLE
Fix typo in partial blacklist example

### DIFF
--- a/docs/blacklist.md
+++ b/docs/blacklist.md
@@ -32,7 +32,7 @@ To disable <kbd>j</kbd> and <kbd>k</kbd> keys (scroll down and up) on github.com
 
 ```json
 {
-  "blacklist" [
+  "blacklist": [
     { "url": "github.com", "keys": ["j", "k"] }
   ]
 }


### PR DESCRIPTION
Minor fix - the provided JSON file was missing a ':'.