### PR TITLE
Fix set command completions

### DIFF
--- a/src/console/actions/console.ts
+++ b/src/console/actions/console.ts
@@ -243,7 +243,7 @@ const getPropertyCompletions = async (
         return [
           {
             caption: item.name,
-            content: name + " " + item.name,
+            content: command + " " + item.name,
             url: "Set " + desc,
           },
         ];


### PR DESCRIPTION
Fix an issue on completion of `set` command.  Property names with "set " prefix should be suggested with an input `"set "`, but not actually.