### PR TITLE
Supports dark mode

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -136,6 +136,7 @@ main {
 
     pre > code {
       background: none;
+      padding: .2em 0;
     }
 
     code {

--- a/docs/properties.md
+++ b/docs/properties.md
@@ -52,3 +52,19 @@ Each character represents the following:
 ```
 :set complete=sbh
 ```
+
+## `colorscheme`
+
+Set color scheme on the console.  The allowed value is one of `light`, `dark`,
+and `system` (default).  `light` and `dark` indicate the light-mode and
+dark-mode are used in the console, respectively.  `system` indicate the
+preferred color configured by system settings is used (see also
+[prefers-color-scheme][]).
+
+```
+set colorscheme=system     " Use system settings
+set colorscheme=light      " Light mode
+set colorscheme=dark       " Dark mode
+```
+
+[prefers-color-scheme]: https://developer.mozilla.org/docs/Web/CSS/@media/prefers-color-scheme

--- a/e2e/colorscheme.test.ts
+++ b/e2e/colorscheme.test.ts
@@ -1,0 +1,60 @@
+import * as path from "path";
+import * as assert from "assert";
+
+import TestServer from "./lib/TestServer";
+import { Builder, Lanthan } from "lanthan";
+import { WebDriver } from "selenium-webdriver";
+import { Options as FirefoxOptions } from "selenium-webdriver/firefox";
+import Page from "./lib/Page";
+
+describe("colorscheme test", () => {
+  const server = new TestServer();
+  let lanthan: Lanthan;
+  let webdriver: WebDriver;
+  let page: Page;
+
+  before(async () => {
+    const opts = (new FirefoxOptions() as any).setPreference(
+      "ui.systemUsesDarkTheme",
+      1
+    );
+
+    lanthan = await Builder.forBrowser("firefox")
+      .setOptions(opts)
+      .spyAddon(path.join(__dirname, ".."))
+      .build();
+    webdriver = lanthan.getWebDriver();
+
+    await server.start();
+  });
+
+  after(async () => {
+    await server.stop();
+    if (lanthan) {
+      await lanthan.quit();
+    }
+  });
+
+  beforeEach(async () => {
+    page = await Page.navigateTo(webdriver, server.url());
+  });
+
+  it("changes color scheme by set command", async () => {
+    let console = await page.showConsole();
+
+    await console.execCommand("set colorscheme=dark");
+    await (webdriver.switchTo() as any).parentFrame();
+    console = await page.showConsole();
+    assert.strictEqual(await console.getTheme(), "dark");
+
+    await console.execCommand("set colorscheme=light");
+    await (webdriver.switchTo() as any).parentFrame();
+    console = await page.showConsole();
+    assert.strictEqual(await console.getTheme(), "light");
+
+    await console.execCommand("set colorscheme=system");
+    await (webdriver.switchTo() as any).parentFrame();
+    console = await page.showConsole();
+    assert.strictEqual(await console.getTheme(), "dark");
+  });
+});

--- a/e2e/completion_set.test.ts
+++ b/e2e/completion_set.test.ts
@@ -34,12 +34,13 @@ describe("completion on set commands", () => {
 
     await eventually(async () => {
       const items = await console.getCompletions();
-      assert.strictEqual(items.length, 5);
+      assert.strictEqual(items.length, 6);
       assert.deepStrictEqual(items[0], { type: "title", text: "Properties" });
       assert.ok(items[1].text.startsWith("hintchars"));
       assert.ok(items[2].text.startsWith("smoothscroll"));
       assert.ok(items[3].text.startsWith("nosmoothscroll"));
       assert.ok(items[4].text.startsWith("complete"));
+      assert.ok(items[5].text.startsWith("colorscheme"));
     });
   });
 

--- a/e2e/lib/Console.ts
+++ b/e2e/lib/Console.ts
@@ -76,6 +76,12 @@ export class Console {
     });
   }
 
+  async getTheme(): Promise<string> {
+    const wrapper = await this.webdriver.findElement(By.css("div[data-theme]"));
+    const theme = await wrapper.getAttribute("data-theme");
+    return theme;
+  }
+
   async close(): Promise<void> {
     const input = await this.webdriver.findElement(By.css("input"));
     await input.sendKeys(Key.ESCAPE);

--- a/src/background/controllers/CompletionController.ts
+++ b/src/background/controllers/CompletionController.ts
@@ -4,7 +4,7 @@ import {
   ConsoleRequestBookmarksResponse,
   ConsoleRequestHistoryResponse,
   ConsoleRequestSearchEnginesResponse,
-  ConsoleRequesttabsResponse,
+  ConsoleRequestTabsResponse,
 } from "../../shared/messages";
 import { injectable } from "tsyringe";
 import OpenCompletionUseCase from "../completion/OpenCompletionUseCase";
@@ -43,7 +43,7 @@ export default class CompletionController {
   async queryTabs(
     query: string,
     excludePinned: boolean
-  ): Promise<ConsoleRequesttabsResponse> {
+  ): Promise<ConsoleRequestTabsResponse> {
     return this.tabCompletionUseCase.queryTabs(query, excludePinned);
   }
 

--- a/src/background/repositories/CachedSettingRepository.ts
+++ b/src/background/repositories/CachedSettingRepository.ts
@@ -1,6 +1,7 @@
 import MemoryStorage from "../infrastructures/MemoryStorage";
 import Settings from "../../shared/settings/Settings";
 import Properties from "../../shared/settings/Properties";
+import ColorScheme from "../../shared/ColorScheme";
 
 const CACHED_SETTING_KEY = "setting";
 
@@ -56,6 +57,18 @@ export class CachedSettingRepositoryImpl implements CachedSettingRepository {
       case "complete":
         current.properties.complete = newValue as string;
         break;
+      case "colorscheme": {
+        switch (newValue) {
+          case ColorScheme.Light:
+          case ColorScheme.Dark:
+          case ColorScheme.System:
+            current.properties.colorscheme = newValue as ColorScheme;
+            break;
+          default:
+            throw new Error(`Unsupported colorscheme: ${newValue}`);
+        }
+        break;
+      }
     }
     await this.update(current);
   }

--- a/src/console/actions/console.ts
+++ b/src/console/actions/console.ts
@@ -26,6 +26,7 @@ const propertyDocs: { [key: string]: string } = {
   hintchars: "hint characters on follow mode",
   smoothscroll: "smooth scroll",
   complete: "which are completed at the open page",
+  colorscheme: "color scheme of the console",
 };
 
 const hide = (): actions.ConsoleAction => {

--- a/src/console/actions/console.ts
+++ b/src/console/actions/console.ts
@@ -2,11 +2,13 @@ import * as messages from "../../shared/messages";
 import * as actions from "./index";
 import { Command } from "../../shared/Command";
 import CompletionClient from "../clients/CompletionClient";
+import SettingClient from "../clients/SettingClient";
 import CompletionType from "../../shared/CompletionType";
 import Completions from "../Completions";
 import TabFlag from "../../shared/TabFlag";
 
 const completionClient = new CompletionClient();
+const settingClient = new SettingClient();
 
 const commandDocs = {
   [Command.Set]: "Set a value of the property",
@@ -272,6 +274,14 @@ const completionPrev = (): actions.CompletionPrevAction => {
   };
 };
 
+const setColorScheme = async (): Promise<actions.SetColorSchemeAction> => {
+  const scheme = await settingClient.getColorScheme();
+  return {
+    type: actions.CONSOLE_SET_COLORSCHEME,
+    colorscheme: scheme,
+  };
+};
+
 export {
   hide,
   showCommand,
@@ -288,4 +298,5 @@ export {
   getPropertyCompletions,
   completionNext,
   completionPrev,
+  setColorScheme,
 };

--- a/src/console/actions/index.ts
+++ b/src/console/actions/index.ts
@@ -1,5 +1,6 @@
 import Completions from "../Completions";
 import CompletionType from "../../shared/CompletionType";
+import ColorScheme from "../../shared/ColorScheme";
 
 export const CONSOLE_HIDE = "console.hide";
 export const CONSOLE_SHOW_COMMAND = "console.show.command";
@@ -11,6 +12,7 @@ export const CONSOLE_SET_COMPLETIONS = "console.set.completions";
 export const CONSOLE_COMPLETION_NEXT = "console.completion.next";
 export const CONSOLE_COMPLETION_PREV = "console.completion.prev";
 export const CONSOLE_SHOW_FIND = "console.show.find";
+export const CONSOLE_SET_COLORSCHEME = "console.set.colorscheme";
 
 export interface HideAction {
   type: typeof CONSOLE_HIDE;
@@ -59,6 +61,11 @@ export interface CompletionPrevAction {
   type: typeof CONSOLE_COMPLETION_PREV;
 }
 
+export interface SetColorSchemeAction {
+  type: typeof CONSOLE_SET_COLORSCHEME;
+  colorscheme: ColorScheme;
+}
+
 export type ConsoleAction =
   | HideAction
   | ShowCommand
@@ -69,4 +76,5 @@ export type ConsoleAction =
   | SetConsoleTextAction
   | SetCompletionsAction
   | CompletionNextAction
-  | CompletionPrevAction;
+  | CompletionPrevAction
+  | SetColorSchemeAction;

--- a/src/console/clients/CompletionClient.ts
+++ b/src/console/clients/CompletionClient.ts
@@ -5,7 +5,7 @@ import {
   ConsoleRequestBookmarksResponse,
   ConsoleRequestHistoryResponse,
   ConsoleRequestSearchEnginesResponse,
-  ConsoleRequesttabsResponse,
+  ConsoleRequestTabsResponse,
 } from "../../shared/messages";
 import CompletionType from "../../shared/CompletionType";
 import TabFlag from "../../shared/TabFlag";
@@ -74,7 +74,7 @@ export default class CompletionClient {
       type: messages.CONSOLE_REQUEST_TABS,
       query,
       excludePinned,
-    })) as ConsoleRequesttabsResponse;
+    })) as ConsoleRequestTabsResponse;
     return resp;
   }
 

--- a/src/console/clients/SettingClient.ts
+++ b/src/console/clients/SettingClient.ts
@@ -1,0 +1,13 @@
+import Settings from "../../shared/settings/Settings";
+import * as messages from "../../shared/messages";
+import ColorScheme from "../../shared/ColorScheme";
+
+export default class SettingClient {
+  async getColorScheme(): Promise<ColorScheme> {
+    const json = await browser.runtime.sendMessage({
+      type: messages.SETTINGS_QUERY,
+    });
+    const settings = Settings.fromJSON(json);
+    return settings.properties.colorscheme;
+  }
+}

--- a/src/console/components/Console.tsx
+++ b/src/console/components/Console.tsx
@@ -10,6 +10,7 @@ import CommandLineParser, {
   InputPhase,
 } from "../commandline/CommandLineParser";
 import { Command } from "../../shared/Command";
+import ColorScheme from "../../shared/ColorScheme";
 
 const COMPLETION_MAX_ITEMS = 33;
 
@@ -126,11 +127,23 @@ class Console extends React.Component<Props> {
   }
 
   render() {
+    let theme = this.props.colorscheme;
+    if (this.props.colorscheme === ColorScheme.System) {
+      if (
+        window.matchMedia &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches
+      ) {
+        theme = ColorScheme.Dark;
+      } else {
+        theme = ColorScheme.Light;
+      }
+    }
+
     switch (this.props.mode) {
       case "command":
       case "find":
         return (
-          <div className="vimvixen-console-command-wrapper">
+          <div data-theme={theme} className="vimvixen-console-command-wrapper">
             <Completion
               size={COMPLETION_MAX_ITEMS}
               completions={this.props.completions}
@@ -149,14 +162,18 @@ class Console extends React.Component<Props> {
       case "info":
       case "error":
         return (
-          <Message mode={this.props.mode}>{this.props.messageText}</Message>
+          <div data-theme={theme}>
+            <Message mode={this.props.mode}>{this.props.messageText}</Message>
+          </div>
         );
       default:
         return null;
     }
   }
 
-  focus() {
+  async focus() {
+    this.props.dispatch(consoleActions.setColorScheme());
+
     window.focus();
     if (this.input.current) {
       this.input.current.focus();

--- a/src/console/components/console.scss
+++ b/src/console/components/console.scss
@@ -1,4 +1,4 @@
-:root {
+[data-theme="light"] {
   --completion-title-background: lightgray;
   --completion-title-foreground: #000000;
   --completion-item-background: #ffffff;
@@ -12,6 +12,22 @@
   --console-error-foreground: #ffffff;
   --console-info-background: #ffffff;
   --console-info-foreground: #018786;
+}
+
+[data-theme="dark"] {
+  --completion-title-background: #052027;
+  --completion-title-foreground: white;
+  --completion-item-background: #2f474f;
+  --completion-item-foreground: white;
+  --completion-item-description-foreground: #86fab0;
+  --completion-selected-background: #eeff41;
+  --completion-selected-foreground: #000000;
+  --command-background: #052027;
+  --command-foreground: white;
+  --console-error-background: red;
+  --console-error-foreground: white;
+  --console-info-background: #052027;
+  --console-info-foreground: #ffffff;
 }
 
 html, body, * {

--- a/src/console/components/console.scss
+++ b/src/console/components/console.scss
@@ -1,3 +1,17 @@
+$completion-title-background: lightgray;
+$completion-title-foreground: #000000;
+$completion-item-background: #ffffff;
+$completion-item-foreground: #000000;
+$completion-item-description-foreground: #008000;
+$completion-selected-background: #ffff00;
+$completion-selected-foreground: #000000;
+$command-background: #ffffff;
+$command-foreground: #000000;
+$console-error-background: #ff0000;
+$console-error-foreground: #ffffff;
+$console-info-background: #ffffff;
+$console-info-foreground: #018786;
+
 html, body, * {
   margin: 0;
   padding: 0;
@@ -16,7 +30,7 @@ body {
   margin: 0;
   padding: 0;
 
-  @mixin consoole-font {
+  @mixin console-font {
     font-style: normal;
     font-family: monospace;
     font-size: 12px;
@@ -28,18 +42,20 @@ body {
   }
 
   &-completion {
-    background-color: white;
-
-    @include consoole-font;
+    @include console-font;
 
     &-title {
-      background-color: lightgray;
+      background-color: $completion-title-background;
+      color: $completion-title-foreground;
       font-weight: bold;
       margin: 0;
       padding: 0;
     }
 
     &-item {
+      background-color: $completion-item-background;
+      color: $completion-item-foreground;
+
       padding-left: 1.5rem;
       background-position: 0 center;
       background-size: contain;
@@ -47,7 +63,8 @@ body {
       white-space: pre;
 
       &.vimvixen-completion-selected {
-        background-color: yellow;
+        background-color: $completion-selected-background;
+        color: $completion-selected-foreground;
       }
 
       &-caption {
@@ -59,7 +76,7 @@ body {
 
       &-url {
         display: inline-block;
-        color: green;
+        color: $completion-item-description-foreground;
         width: 60%;
         text-overflow: ellipsis;
         overflow: hidden;
@@ -68,36 +85,39 @@ body {
   }
 
   &-message {
-    @include consoole-font;
+    @include console-font;
 
     border-top: 1px solid gray;
   }
 
   &-error {
-    background-color: red;
+    background-color: $console-error-background;
+    color: $console-error-foreground;
     font-weight: bold;
-    color: white;
   }
 
   &-info {
-    background-color: white;
+    background-color: $console-info-background;
+    color: $console-info-foreground;
     font-weight: normal;
-    color: green;
   }
 
   &-command {
-    background-color: white;
+    background-color: $command-background;
+    color: $command-foreground;
     display: flex;
 
     &-prompt {
-      @include consoole-font;
+      @include console-font;
     }
 
     &-input {
       border: none;
       flex-grow: 1;
+      background-color: $command-background;
+      color: $command-foreground;
 
-      @include consoole-font;
+      @include console-font;
     }
   }
 }

--- a/src/console/components/console.scss
+++ b/src/console/components/console.scss
@@ -1,16 +1,18 @@
-$completion-title-background: lightgray;
-$completion-title-foreground: #000000;
-$completion-item-background: #ffffff;
-$completion-item-foreground: #000000;
-$completion-item-description-foreground: #008000;
-$completion-selected-background: #ffff00;
-$completion-selected-foreground: #000000;
-$command-background: #ffffff;
-$command-foreground: #000000;
-$console-error-background: #ff0000;
-$console-error-foreground: #ffffff;
-$console-info-background: #ffffff;
-$console-info-foreground: #018786;
+:root {
+  --completion-title-background: lightgray;
+  --completion-title-foreground: #000000;
+  --completion-item-background: #ffffff;
+  --completion-item-foreground: #000000;
+  --completion-item-description-foreground: #008000;
+  --completion-selected-background: #ffff00;
+  --completion-selected-foreground: #000000;
+  --command-background: #ffffff;
+  --command-foreground: #000000;
+  --console-error-background: #ff0000;
+  --console-error-foreground: #ffffff;
+  --console-info-background: #ffffff;
+  --console-info-foreground: #018786;
+}
 
 html, body, * {
   margin: 0;
@@ -45,16 +47,16 @@ body {
     @include console-font;
 
     &-title {
-      background-color: $completion-title-background;
-      color: $completion-title-foreground;
+      background-color: var(--completion-title-background);
+      color: var(--completion-title-foreground);
       font-weight: bold;
       margin: 0;
       padding: 0;
     }
 
     &-item {
-      background-color: $completion-item-background;
-      color: $completion-item-foreground;
+      background-color: var(--completion-item-background);
+      color: var(--completion-item-foreground);
 
       padding-left: 1.5rem;
       background-position: 0 center;
@@ -63,8 +65,8 @@ body {
       white-space: pre;
 
       &.vimvixen-completion-selected {
-        background-color: $completion-selected-background;
-        color: $completion-selected-foreground;
+        background-color: var(--completion-selected-background);
+        color: var(--completion-selected-foreground);
       }
 
       &-caption {
@@ -76,7 +78,7 @@ body {
 
       &-url {
         display: inline-block;
-        color: $completion-item-description-foreground;
+        color: var(--completion-item-description-foreground);
         width: 60%;
         text-overflow: ellipsis;
         overflow: hidden;
@@ -91,20 +93,20 @@ body {
   }
 
   &-error {
-    background-color: $console-error-background;
-    color: $console-error-foreground;
+    background-color: var(--console-error-background);
+    color: var(--console-error-foreground);
     font-weight: bold;
   }
 
   &-info {
-    background-color: $console-info-background;
-    color: $console-info-foreground;
+    background-color: var(--console-info-background);
+    color: var(--console-info-foreground);
     font-weight: normal;
   }
 
   &-command {
-    background-color: $command-background;
-    color: $command-foreground;
+    background-color: var(--command-background);
+    color: var(--command-foreground);
     display: flex;
 
     &-prompt {
@@ -114,8 +116,8 @@ body {
     &-input {
       border: none;
       flex-grow: 1;
-      background-color: $command-background;
-      color: $command-foreground;
+      background-color: var(--command-background);
+      color: var(--command-foreground);
 
       @include console-font;
     }

--- a/src/console/index.html
+++ b/src/console/index.html
@@ -5,7 +5,7 @@
     <title>VimVixen console</title>
     <script src='console.js'></script>
   </head>
-  <body>
+  <body data-theme="light">
     <div id='vimvixen-console' class='vimvixen-console'></div>
   </body>
 </html>

--- a/src/console/index.html
+++ b/src/console/index.html
@@ -5,7 +5,7 @@
     <title>VimVixen console</title>
     <script src='console.js'></script>
   </head>
-  <body data-theme="light">
+  <body>
     <div id='vimvixen-console' class='vimvixen-console'></div>
   </body>
 </html>

--- a/src/console/reducers/index.ts
+++ b/src/console/reducers/index.ts
@@ -1,6 +1,7 @@
 import * as actions from "../actions";
 import Completions from "../Completions";
 import CompletionType from "../../shared/CompletionType";
+import ColorScheme from "../../shared/ColorScheme";
 
 export interface State {
   mode: string;
@@ -11,6 +12,7 @@ export interface State {
   completions: Completions;
   select: number;
   viewIndex: number;
+  colorscheme: ColorScheme;
 }
 
 const defaultState = {
@@ -22,6 +24,7 @@ const defaultState = {
   completions: [],
   select: -1,
   viewIndex: 0,
+  colorscheme: ColorScheme.System,
 };
 
 const nextSelection = (state: State): number => {
@@ -122,6 +125,11 @@ export default function reducer(
         ),
       };
     }
+    case actions.CONSOLE_SET_COLORSCHEME:
+      return {
+        ...state,
+        colorscheme: action.colorscheme,
+      };
     default:
       return state;
   }

--- a/src/shared/ColorScheme.ts
+++ b/src/shared/ColorScheme.ts
@@ -1,0 +1,7 @@
+enum ColorScheme {
+  System = "system",
+  Light = "light",
+  Dark = "dark",
+}
+
+export default ColorScheme;

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -127,7 +127,7 @@ export interface ConsoleGetPropertiesMessage {
   type: typeof CONSOLE_GET_PROPERTIES;
 }
 
-export type ConsoleRequesttabsResponse = {
+export type ConsoleRequestTabsResponse = {
   index: number;
   flag: TabFlag;
   title: string;

--- a/src/shared/settings/Properties.ts
+++ b/src/shared/settings/Properties.ts
@@ -1,16 +1,24 @@
+enum ColorScheme {
+  System = "system",
+  Light = "light",
+  Dark = "dark",
+}
+
 export type PropertiesJSON = {
   hintchars?: string;
   smoothscroll?: boolean;
   complete?: string;
+  colorscheme?: ColorScheme;
 };
 
 export type PropertyTypes = {
   hintchars: string;
   smoothscroll: string;
   complete: string;
+  colorscheme: string;
 };
 
-type PropertyName = "hintchars" | "smoothscroll" | "complete";
+type PropertyName = "hintchars" | "smoothscroll" | "complete" | "colorscheme";
 
 type PropertyDef = {
   name: PropertyName;
@@ -38,12 +46,19 @@ const defs: PropertyDef[] = [
     defaultValue: "sbh",
     type: "string",
   },
+  {
+    name: "colorscheme",
+    description: "color scheme of the console",
+    defaultValue: ColorScheme.System,
+    type: "string",
+  },
 ];
 
 const defaultValues = {
   hintchars: "abcdefghijklmnopqrstuvwxyz",
   smoothscroll: false,
   complete: "sbh",
+  colorscheme: ColorScheme.System,
 };
 
 export default class Properties {
@@ -53,18 +68,23 @@ export default class Properties {
 
   public complete: string;
 
+  public colorscheme: ColorScheme;
+
   constructor({
     hintchars,
     smoothscroll,
     complete,
+    colorscheme,
   }: {
     hintchars?: string;
     smoothscroll?: boolean;
     complete?: string;
+    colorscheme?: ColorScheme;
   } = {}) {
     this.hintchars = hintchars || defaultValues.hintchars;
     this.smoothscroll = smoothscroll || defaultValues.smoothscroll;
     this.complete = complete || defaultValues.complete;
+    this.colorscheme = colorscheme || defaultValues.colorscheme;
   }
 
   static fromJSON(json: PropertiesJSON): Properties {
@@ -76,6 +96,7 @@ export default class Properties {
       hintchars: "string",
       smoothscroll: "boolean",
       complete: "string",
+      colorscheme: "string",
     };
   }
 
@@ -92,6 +113,7 @@ export default class Properties {
       hintchars: this.hintchars,
       smoothscroll: this.smoothscroll,
       complete: this.complete,
+      colorscheme: this.colorscheme,
     };
   }
 }

--- a/src/shared/settings/Properties.ts
+++ b/src/shared/settings/Properties.ts
@@ -22,7 +22,6 @@ type PropertyName = "hintchars" | "smoothscroll" | "complete" | "colorscheme";
 
 type PropertyDef = {
   name: PropertyName;
-  description: string;
   defaultValue: string | number | boolean;
   type: "string" | "number" | "boolean";
 };
@@ -30,25 +29,21 @@ type PropertyDef = {
 const defs: PropertyDef[] = [
   {
     name: "hintchars",
-    description: "hint characters on follow mode",
     defaultValue: "abcdefghijklmnopqrstuvwxyz",
     type: "string",
   },
   {
     name: "smoothscroll",
-    description: "smooth scroll",
     defaultValue: false,
     type: "boolean",
   },
   {
     name: "complete",
-    description: "which are completed at the open page",
     defaultValue: "sbh",
     type: "string",
   },
   {
     name: "colorscheme",
-    description: "color scheme of the console",
     defaultValue: ColorScheme.System,
     type: "string",
   },

--- a/src/shared/settings/Properties.ts
+++ b/src/shared/settings/Properties.ts
@@ -1,8 +1,4 @@
-enum ColorScheme {
-  System = "system",
-  Light = "light",
-  Dark = "dark",
-}
+import ColorScheme from "../ColorScheme";
 
 export type PropertiesJSON = {
   hintchars?: string;

--- a/src/shared/settings/Settings.ts
+++ b/src/shared/settings/Settings.ts
@@ -156,7 +156,8 @@ export const DefaultSettingJSONText = `{
   "properties": {
     "hintchars": "abcdefghijklmnopqrstuvwxyz",
     "smoothscroll": false,
-    "complete": "sbh"
+    "complete": "sbh",
+    "colorscheme": "system"
   },
   "blacklist": [
   ]

--- a/src/shared/settings/schema.json
+++ b/src/shared/settings/schema.json
@@ -48,6 +48,10 @@
         },
         "complete": {
           "type": "string"
+        },
+        "colorscheme": {
+          "type": "string",
+          "enum": ["system", "light", "dark"]
         }
       }
     },

--- a/src/shared/settings/validate.js
+++ b/src/shared/settings/validate.js
@@ -1,4 +1,5 @@
 'use strict';
+var equal = require('ajv/lib/compile/equal');
 var validate = (function() {
   var pattern0 = new RegExp('.*');
   var refVal = [];
@@ -273,6 +274,46 @@ var validate = (function() {
                       }
                       var valid2 = errors === errs_2;
                     }
+                    if (valid2) {
+                      var data2 = data1.colorscheme;
+                      if (data2 === undefined) {
+                        valid2 = true;
+                      } else {
+                        var errs_2 = errors;
+                        if (typeof data2 !== "string") {
+                          validate.errors = [{
+                            keyword: 'type',
+                            dataPath: (dataPath || '') + '.properties.colorscheme',
+                            schemaPath: '#/properties/properties/properties/colorscheme/type',
+                            params: {
+                              type: 'string'
+                            },
+                            message: 'should be string'
+                          }];
+                          return false;
+                        }
+                        var schema2 = validate.schema.properties.properties.properties.colorscheme.enum;
+                        var valid2;
+                        valid2 = false;
+                        for (var i2 = 0; i2 < schema2.length; i2++)
+                          if (equal(data2, schema2[i2])) {
+                            valid2 = true;
+                            break;
+                          } if (!valid2) {
+                          validate.errors = [{
+                            keyword: 'enum',
+                            dataPath: (dataPath || '') + '.properties.colorscheme',
+                            schemaPath: '#/properties/properties/properties/colorscheme/enum',
+                            params: {
+                              allowedValues: schema2
+                            },
+                            message: 'should be equal to one of the allowed values'
+                          }];
+                          return false;
+                        }
+                        var valid2 = errors === errs_2;
+                      }
+                    }
                   }
                 }
               } else {
@@ -535,6 +576,10 @@ validate.schema = {
         },
         "complete": {
           "type": "string"
+        },
+        "colorscheme": {
+          "type": "string",
+          "enum": ["system", "light", "dark"]
         }
       }
     },

--- a/test/shared/SettingData.test.ts
+++ b/test/shared/SettingData.test.ts
@@ -6,6 +6,7 @@ import SettingData, {
 import Settings from "../../src/shared/settings/Settings";
 import { expect } from "chai";
 import Keymaps from "../../src/shared/settings/Keymaps";
+import ColorScheme from "../../src/shared/ColorScheme";
 
 describe("shared/SettingData", () => {
   describe("FormKeymaps", () => {
@@ -54,7 +55,8 @@ describe("shared/SettingData", () => {
           "properties": {
             "hintchars": "abcdefghijklmnopqrstuvwxyz",
             "smoothscroll": false,
-            "complete": "sbh"
+            "complete": "sbh",
+            "colorscheme": "system"
           },
           "blacklist": []
         }`;
@@ -104,6 +106,7 @@ describe("shared/SettingData", () => {
             hintchars: "abcdefghijklmnopqrstuvwxyz",
             smoothscroll: false,
             complete: "sbh",
+            colorscheme: ColorScheme.System,
           },
           blacklist: [],
         };
@@ -124,6 +127,7 @@ describe("shared/SettingData", () => {
             hintchars: "abcdefghijklmnopqrstuvwxyz",
             smoothscroll: false,
             complete: "sbh",
+            colorscheme: "system",
           },
           blacklist: [],
         });
@@ -147,6 +151,7 @@ describe("shared/SettingData", () => {
             hintchars: "abcdefghijklmnopqrstuvwxyz",
             smoothscroll: false,
             complete: "sbh",
+            colorscheme: ColorScheme.System,
           },
           blacklist: [],
         });
@@ -165,6 +170,7 @@ describe("shared/SettingData", () => {
             hintchars: "abcdefghijklmnopqrstuvwxyz",
             smoothscroll: false,
             complete: "sbh",
+            colorscheme: "system",
           },
           blacklist: [],
         });
@@ -188,7 +194,8 @@ describe("shared/SettingData", () => {
             "properties": {
               "hintchars": "abcdefghijklmnopqrstuvwxyz",
               "smoothscroll": false,
-              "complete": "sbh"
+              "complete": "sbh",
+              "colorscheme": "system"
             },
             "blacklist": []
           }`,
@@ -212,6 +219,7 @@ describe("shared/SettingData", () => {
               hintchars: "abcdefghijklmnopqrstuvwxyz",
               smoothscroll: false,
               complete: "sbh",
+              colorscheme: ColorScheme.System,
             },
             blacklist: [],
           },
@@ -229,6 +237,7 @@ describe("shared/SettingData", () => {
             hintchars: "abcdefghijklmnopqrstuvwxyz",
             smoothscroll: false,
             complete: "sbh",
+            colorscheme: "system",
           },
           blacklist: [],
         });

--- a/test/shared/settings/Properties.test.ts
+++ b/test/shared/settings/Properties.test.ts
@@ -1,5 +1,6 @@
 import Properties from "../../../src/shared/settings/Properties";
 import { expect } from "chai";
+import ColorScheme from "../../../src/shared/ColorScheme";
 
 describe("Properties", () => {
   describe("#propertiesValueOf", () => {
@@ -9,6 +10,7 @@ describe("Properties", () => {
         hintchars: "abcdefghijklmnopqrstuvwxyz",
         smoothscroll: false,
         complete: "sbh",
+        colorscheme: "system",
       });
     });
 
@@ -17,12 +19,14 @@ describe("Properties", () => {
         hintchars: "abcdefgh",
         smoothscroll: false,
         complete: "sbh",
+        colorscheme: ColorScheme.System,
       });
 
       expect(props).to.deep.equal({
         hintchars: "abcdefgh",
         smoothscroll: false,
         complete: "sbh",
+        colorscheme: "system",
       });
     });
   });

--- a/test/shared/settings/Settings.test.ts
+++ b/test/shared/settings/Settings.test.ts
@@ -33,6 +33,7 @@ describe("Settings", () => {
           hintchars: "abcdefghijklmnopqrstuvwxyz",
           smoothscroll: false,
           complete: "sbh",
+          colorscheme: "system",
         },
         blacklist: [],
       });


### PR DESCRIPTION
This change allow you to choose color scheme of the console from light-mode and dark-mode.  The new property `colorscheme` enables to change thee types of color schemes.

The allowed value is one of `light`, `dark`, and `system` (default).  `light` and `dark` indicate the light-mode and dark-mode are used in the console, respectively.  `system` indicate the preferred color configured by system settings is used (see also [prefers-color-scheme][]).

[prefers-color-scheme]: https://developer.mozilla.org/docs/Web/CSS/@media/prefers-color-scheme


```console
set colorscheme=system     " Use system settings
set colorscheme=light      " Light mode
set colorscheme=dark       " Dark mode
```

### light mode

<img width="706" alt="72566697-3b618a80-38ac-11ea-9f18-a4b8b2a4c666" src="https://user-images.githubusercontent.com/534166/80944060-98655a00-8e23-11ea-9a5a-3c26084a6ee3.png">

### dark mode

<img width="706" alt="72566684-369cd680-38ac-11ea-8edb-b084e4f72bc7" src="https://user-images.githubusercontent.com/534166/80944085-ac10c080-8e23-11ea-99bb-c888d1fff0ec.png">
