### PR TITLE
Fixed issues with following the first link

### DIFF
--- a/src/content/usecases/FollowMasterUseCase.ts
+++ b/src/content/usecases/FollowMasterUseCase.ts
@@ -58,6 +58,7 @@ export default class FollowMasterUseCase {
   // eslint-disable-next-line max-statements
   createSlaveHints(count: number, sender: Window): void {
     const produced = [];
+    this.producer!.setNumberOfHints(count);
     for (let i = 0; i < count; ++i) {
       const tag = this.producer!!.produce();
       produced.push(tag);

--- a/src/content/usecases/HintKeyProducer.ts
+++ b/src/content/usecases/HintKeyProducer.ts
@@ -13,7 +13,9 @@ export default class HintKeyProducer {
   }
 
   setNumberOfHints(nHints: number): void {
-    const charsPrKey : number = Math.ceil(Math.log(nHints) / Math.log(this.charset.length));
+    const charsPrKey: number = Math.ceil(
+      Math.log(nHints) / Math.log(this.charset.length)
+    );
     this.counter = new Array(charsPrKey).fill(0);
   }
 

--- a/src/content/usecases/HintKeyProducer.ts
+++ b/src/content/usecases/HintKeyProducer.ts
@@ -12,6 +12,11 @@ export default class HintKeyProducer {
     this.counter = [];
   }
 
+  setNumberOfHints(nHints: number): void {
+    const charsPrKey : number = Math.ceil(Math.log(nHints) / Math.log(this.charset.length));
+    this.counter = new Array(charsPrKey).fill(0);
+  }
+
   produce(): string {
     this.increment();
 


### PR DESCRIPTION
I noticed a bug when trying to follow the first link on a website with more links than characters in the charset. 
When pressing 'A', after the hints are shown, all hints starting with 'A' is shown, but there is no way I can pick the hint with the tag 'A'.

Steps to reproduce:
1. Go to a website with more links than characters in the charset (default 27).
2. Press 'f'.
3. Try to follow the link with tag = 'A'.

I have come up with a solution to the problem by filling the counter in the HintKeyProducer with a number of 0's corresponding to the number of characters that is needed in each tag to make them unique.