### PR TITLE
multiple window feature in buffer explorer

### DIFF
--- a/src/background/completion/TabCompletionUseCase.ts
+++ b/src/background/completion/TabCompletionUseCase.ts
@@ -11,9 +11,9 @@ export default class TabCompletionUseCase {
     @inject("TabPresenter") private tabPresenter: TabPresenter
   ) {}
 
-  async queryTabs(query: string, excludePinned: boolean): Promise<TabItem[]> {
+  async queryTabs(query: string, excludePinned: boolean, onlyCurrentWin: boolean): Promise<TabItem[]> {
     const lastTabId = await this.tabPresenter.getLastSelectedId();
-    const allTabs = await this.tabRepository.getAllTabs(excludePinned);
+    const allTabs = await this.tabRepository.getAllTabs(excludePinned, onlyCurrentWin);
     const num = parseInt(query, 10);
     let tabs: Tab[] = [];
     if (!isNaN(num)) {
@@ -32,7 +32,7 @@ export default class TabCompletionUseCase {
         tabs = [tab];
       }
     } else {
-      tabs = await this.tabRepository.queryTabs(query, excludePinned);
+      tabs = await this.tabRepository.queryTabs(query, excludePinned, onlyCurrentWin);
     }
 
     return tabs.map((tab) => {

--- a/src/background/completion/TabCompletionUseCase.ts
+++ b/src/background/completion/TabCompletionUseCase.ts
@@ -12,15 +12,20 @@ export default class TabCompletionUseCase {
   ) {}
 
   async queryTabs(query: string, excludePinned: boolean, onlyCurrentWin: boolean): Promise<TabItem[]> {
+    const multiIndex = (t: Tab) => t.index + 1 + parseFloat('0.' + t.windowId + '1')
     const lastTabId = await this.tabPresenter.getLastSelectedId();
     const allTabs = await this.tabRepository.getAllTabs(excludePinned, onlyCurrentWin);
-    const num = parseInt(query, 10);
+    const num = parseFloat(query);
     let tabs: Tab[] = [];
     if (!isNaN(num)) {
-      const tab = allTabs.find((t) => t.index === num - 1);
-      if (tab) {
-        tabs = [tab];
+      let tab = allTabs.find((t) => t.index === num - 1);
+      if (!tab) {
+        tab = allTabs.find((t) => multiIndex(t) === num);
       }
+      if(tab) {
+        tabs = [tab]
+      }
+
     } else if (query == "%") {
       const tab = allTabs.find((t) => t.active);
       if (tab) {
@@ -34,6 +39,8 @@ export default class TabCompletionUseCase {
     } else {
       tabs = await this.tabRepository.queryTabs(query, excludePinned, onlyCurrentWin);
     }
+    const winSet = tabs.reduce( (wins, tab) => wins.add(tab.windowId), new Set<number>());
+    const multiWin = winSet.size > 1
 
     return tabs.map((tab) => {
       let flag = TabFlag.None;
@@ -43,7 +50,7 @@ export default class TabCompletionUseCase {
         flag = TabFlag.LastTab;
       }
       return {
-        index: tab.index + 1,
+        index: tab.index + 1 + (multiWin ? parseFloat('0.' + tab.windowId + '1') : 0),
         flag: flag,
         title: tab.title,
         url: tab.url,

--- a/src/background/completion/TabRepository.ts
+++ b/src/background/completion/TabRepository.ts
@@ -8,7 +8,7 @@ export type Tab = {
 };
 
 export default interface TabRepository {
-  queryTabs(query: string, excludePinned: boolean): Promise<Tab[]>;
+  queryTabs(query: string, excludePinned: boolean, onlyCurrentWin: boolean): Promise<Tab[]>;
 
-  getAllTabs(excludePinned: boolean): Promise<Tab[]>;
+  getAllTabs(excludePinned: boolean, onlyCurrentWin: boolean): Promise<Tab[]>;
 }

--- a/src/background/completion/TabRepository.ts
+++ b/src/background/completion/TabRepository.ts
@@ -5,6 +5,7 @@ export type Tab = {
   title: string;
   url: string;
   faviconUrl?: string;
+  windowId: number;
 };
 
 export default interface TabRepository {

--- a/src/background/completion/impl/TabRepositoryImpl.ts
+++ b/src/background/completion/impl/TabRepositoryImpl.ts
@@ -1,7 +1,7 @@
 import TabRepository, { Tab } from "../TabRepository";
 
 export default class TabRepositoryImpl implements TabRepository {
-  async queryTabs(query: string, excludePinned: boolean): Promise<Tab[]> {
+  async queryTabs(query: string, excludePinned: boolean, onlyCurrentWin: boolean): Promise<Tab[]> {
     const tabs = await browser.tabs.query({ currentWindow: true });
     return tabs
       .filter((t) => {
@@ -17,13 +17,13 @@ export default class TabRepositoryImpl implements TabRepository {
       .map(TabRepositoryImpl.toEntity);
   }
 
-  async getAllTabs(excludePinned: boolean): Promise<Tab[]> {
+  async getAllTabs(excludePinned: boolean, onlyCurrentWin: boolean): Promise<Tab[]> {
     if (excludePinned) {
       return (
-        await browser.tabs.query({ currentWindow: true, pinned: true })
+        await browser.tabs.query({ currentWindow: onlyCurrentWin, pinned: true })
       ).map(TabRepositoryImpl.toEntity);
     }
-    return (await browser.tabs.query({ currentWindow: true })).map(
+    return (await browser.tabs.query({ currentWindow: onlyCurrentWin })).map(
       TabRepositoryImpl.toEntity
     );
   }

--- a/src/background/completion/impl/TabRepositoryImpl.ts
+++ b/src/background/completion/impl/TabRepositoryImpl.ts
@@ -2,7 +2,10 @@ import TabRepository, { Tab } from "../TabRepository";
 
 export default class TabRepositoryImpl implements TabRepository {
   async queryTabs(query: string, excludePinned: boolean, onlyCurrentWin: boolean): Promise<Tab[]> {
-    const tabs = await browser.tabs.query({ currentWindow: true });
+    const tabs = [
+      ...await browser.tabs.query({ currentWindow: true }),
+      ...(onlyCurrentWin ? [] : await browser.tabs.query({ currentWindow: false }))
+    ]
     return tabs
       .filter((t) => {
         return (
@@ -20,10 +23,16 @@ export default class TabRepositoryImpl implements TabRepository {
   async getAllTabs(excludePinned: boolean, onlyCurrentWin: boolean): Promise<Tab[]> {
     if (excludePinned) {
       return (
-        await browser.tabs.query({ currentWindow: onlyCurrentWin, pinned: true })
+        [
+            ...await browser.tabs.query({ currentWindow: true, pinned: true }),
+            ...(onlyCurrentWin ? [] : await browser.tabs.query({ currentWindow: false, pinned: true }))
+        ]
       ).map(TabRepositoryImpl.toEntity);
     }
-    return (await browser.tabs.query({ currentWindow: onlyCurrentWin })).map(
+    return [
+      ...await browser.tabs.query({ currentWindow: true }),
+      ...(onlyCurrentWin ? [] : await browser.tabs.query({ currentWindow: false }))
+    ].map(
       TabRepositoryImpl.toEntity
     );
   }
@@ -36,6 +45,7 @@ export default class TabRepositoryImpl implements TabRepository {
       title: tab.title!!,
       faviconUrl: tab.favIconUrl,
       index: tab.index,
+      windowId: tab.windowId,
     };
   }
 }

--- a/src/background/controllers/CompletionController.ts
+++ b/src/background/controllers/CompletionController.ts
@@ -42,9 +42,10 @@ export default class CompletionController {
 
   async queryTabs(
     query: string,
-    excludePinned: boolean
+    excludePinned: boolean,
+    onlyCurrentWin: boolean
   ): Promise<ConsoleRequestTabsResponse> {
-    return this.tabCompletionUseCase.queryTabs(query, excludePinned);
+    return this.tabCompletionUseCase.queryTabs(query, excludePinned, onlyCurrentWin);
   }
 
   async getProperties(): Promise<ConsoleGetPropertiesResponse> {

--- a/src/background/infrastructures/ContentMessageListener.ts
+++ b/src/background/infrastructures/ContentMessageListener.ts
@@ -74,7 +74,8 @@ export default class ContentMessageListener {
       case messages.CONSOLE_REQUEST_TABS:
         return this.completionController.queryTabs(
           message.query,
-          message.excludePinned
+          message.excludePinned,
+          message.onlyCurrentWin
         );
       case messages.CONSOLE_GET_PROPERTIES:
         return this.completionController.getProperties();

--- a/src/background/presenters/TabPresenter.ts
+++ b/src/background/presenters/TabPresenter.ts
@@ -91,6 +91,10 @@ export class TabPresenterImpl implements TabPresenter {
 
   async select(tabId: number): Promise<void> {
     await browser.tabs.update(tabId, { active: true });
+    const windowId = (await browser.tabs.get(tabId)).windowId;
+    if((await browser.windows.getCurrent()).id !== windowId) {
+       await browser.windows.update(windowId, {focused: true})
+    }
   }
 
   async remove(ids: number[]): Promise<void> {

--- a/src/background/presenters/TabPresenter.ts
+++ b/src/background/presenters/TabPresenter.ts
@@ -12,11 +12,11 @@ export default interface TabPresenter {
 
   getCurrent(): Promise<Tab>;
 
-  getAll(): Promise<Tab[]>;
+  getAll(onlyCurrentWin?: boolean): Promise<Tab[]>;
 
   getLastSelectedId(): Promise<number | undefined>;
 
-  getByKeyword(keyword: string, excludePinned: boolean): Promise<Tab[]>;
+  getByKeyword(keyword: string, excludePinned: boolean, onlyCurrentWin?: boolean = true): Promise<Tab[]>;
 
   select(tabId: number): Promise<void>;
 
@@ -56,8 +56,8 @@ export class TabPresenterImpl implements TabPresenter {
     return tabs[0];
   }
 
-  getAll(): Promise<Tab[]> {
-    return browser.tabs.query({ currentWindow: true });
+  getAll(onlyCurrentWin?: boolean = true): Promise<Tab[]> {
+    return browser.tabs.query({ currentWindow: onlyCurrentWin });
   }
 
   async getLastSelectedId(): Promise<number | undefined> {
@@ -69,7 +69,7 @@ export class TabPresenterImpl implements TabPresenter {
     return tabId;
   }
 
-  async getByKeyword(keyword: string, excludePinned = false): Promise<Tab[]> {
+  async getByKeyword(keyword: string, excludePinned = false, onlyCurrentWin?: boolean = true): Promise<Tab[]> {
     const tabs = await browser.tabs.query({ currentWindow: true });
     return tabs
       .filter((t) => {

--- a/src/background/repositories/CachedSettingRepository.ts
+++ b/src/background/repositories/CachedSettingRepository.ts
@@ -69,6 +69,10 @@ export class CachedSettingRepositoryImpl implements CachedSettingRepository {
         }
         break;
       }
+      case "searchOnlyCurrentWin":
+        current.properties.searchOnlyCurrentWin = newValue as boolean;
+        break;
+
     }
     await this.update(current);
   }

--- a/src/background/usecases/CommandUseCase.ts
+++ b/src/background/usecases/CommandUseCase.ts
@@ -60,8 +60,10 @@ export default class CommandIndicator {
       return;
     }
 
+    const settings = await this.cachedSettingRepository.get();
+    const onlyCurrentWin = settings.properties.searchOnlyCurrentWin;
     if (!isNaN(Number(keywords))) {
-      const tabs = await this.tabPresenter.getAll();
+      const tabs = await this.tabPresenter.getAll(onlyCurrentWin);
       const index = parseInt(keywords, 10) - 1;
       if (index < 0 || tabs.length <= index) {
         throw new RangeError(`tab ${index + 1} does not exist`);
@@ -80,7 +82,7 @@ export default class CommandIndicator {
     }
 
     const current = await this.tabPresenter.getCurrent();
-    const tabs = await this.tabPresenter.getByKeyword(keywords, false);
+    const tabs = await this.tabPresenter.getByKeyword(keywords, false, onlyCurrentWin);
     if (tabs.length === 0) {
       throw new RangeError("No matching buffer for " + keywords);
     }

--- a/src/console/actions/console.ts
+++ b/src/console/actions/console.ts
@@ -29,6 +29,7 @@ const propertyDocs: { [key: string]: string } = {
   smoothscroll: "smooth scroll",
   complete: "which are completed at the open page",
   colorscheme: "color scheme of the console",
+  searchOnlyCurrentWin: "buffer switch and tab completion only in current browser window"
 };
 
 const hide = (): actions.ConsoleAction => {

--- a/src/console/actions/console.ts
+++ b/src/console/actions/console.ts
@@ -194,9 +194,10 @@ const getTabCompletions = async (
   original: string,
   command: Command,
   query: string,
-  excludePinned: boolean
+  excludePinned: boolean,
 ): Promise<actions.SetCompletionsAction> => {
-  const items = await completionClient.requestTabs(query, excludePinned);
+  const onlyCurrentWin = await settingClient.shouldSearchOnlyCurrentWin();
+  const items = await completionClient.requestTabs(query, excludePinned, onlyCurrentWin);
   let completions: Completions = [];
   if (items.length > 0) {
     completions = [

--- a/src/console/clients/CompletionClient.ts
+++ b/src/console/clients/CompletionClient.ts
@@ -69,11 +69,12 @@ export default class CompletionClient {
     return resp;
   }
 
-  async requestTabs(query: string, excludePinned: boolean): Promise<TabItem[]> {
+  async requestTabs(query: string, excludePinned: boolean, onlyCurrentWin: boolean): Promise<TabItem[]> {
     const resp = (await browser.runtime.sendMessage({
       type: messages.CONSOLE_REQUEST_TABS,
       query,
       excludePinned,
+      onlyCurrentWin
     })) as ConsoleRequestTabsResponse;
     return resp;
   }

--- a/src/console/clients/SettingClient.ts
+++ b/src/console/clients/SettingClient.ts
@@ -1,13 +1,23 @@
 import Settings from "../../shared/settings/Settings";
 import * as messages from "../../shared/messages";
 import ColorScheme from "../../shared/ColorScheme";
+import Properties from "../../shared/settings/Properties";
 
 export default class SettingClient {
-  async getColorScheme(): Promise<ColorScheme> {
+
+  private async getProperties(): Promise<Properties> {
     const json = await browser.runtime.sendMessage({
       type: messages.SETTINGS_QUERY,
     });
     const settings = Settings.fromJSON(json);
-    return settings.properties.colorscheme;
+    return settings.properties;
+  }
+
+  async getColorScheme(): Promise<ColorScheme> {
+    return (await this.getProperties()).colorscheme;
+  }
+
+  async shouldSearchOnlyCurrentWin(): Promise<boolean> {
+    return (await this.getProperties()).searchOnlyCurrentWin;
   }
 }

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -121,6 +121,7 @@ export interface ConsoleRequestTabsMessage {
   type: typeof CONSOLE_REQUEST_TABS;
   query: string;
   excludePinned: boolean;
+  onlyCurrentWin: boolean;
 }
 
 export interface ConsoleGetPropertiesMessage {

--- a/src/shared/settings/Properties.ts
+++ b/src/shared/settings/Properties.ts
@@ -16,7 +16,7 @@ export type PropertyTypes = {
   searchOnlyCurrentWin: string;
 };
 
-type PropertyName = "hintchars" | "smoothscroll" | "complete" | "colorscheme";
+type PropertyName = "hintchars" | "smoothscroll" | "complete" | "colorscheme" | "searchOnlyCurrentWin";
 
 type PropertyDef = {
   name: PropertyName;
@@ -57,7 +57,7 @@ const defaultValues = {
   smoothscroll: false,
   complete: "sbh",
   colorscheme: ColorScheme.System,
-  searchOnlyCurrentWin: true,
+  searchOnlyCurrentWin: false,
 };
 
 export default class Properties {
@@ -101,7 +101,7 @@ export default class Properties {
       smoothscroll: "boolean",
       complete: "string",
       colorscheme: "string",
-      searchOnlyCurrentWin: "string",
+      searchOnlyCurrentWin: "boolean",
     };
   }
 

--- a/src/shared/settings/Properties.ts
+++ b/src/shared/settings/Properties.ts
@@ -5,6 +5,7 @@ export type PropertiesJSON = {
   smoothscroll?: boolean;
   complete?: string;
   colorscheme?: ColorScheme;
+  searchOnlyCurrentWin?: boolean;
 };
 
 export type PropertyTypes = {
@@ -12,6 +13,7 @@ export type PropertyTypes = {
   smoothscroll: string;
   complete: string;
   colorscheme: string;
+  searchOnlyCurrentWin: string;
 };
 
 type PropertyName = "hintchars" | "smoothscroll" | "complete" | "colorscheme";
@@ -43,6 +45,11 @@ const defs: PropertyDef[] = [
     defaultValue: ColorScheme.System,
     type: "string",
   },
+  {
+    name: "searchOnlyCurrentWin",
+    defaultValue: true,
+    type: "boolean",
+  },
 ];
 
 const defaultValues = {
@@ -50,6 +57,7 @@ const defaultValues = {
   smoothscroll: false,
   complete: "sbh",
   colorscheme: ColorScheme.System,
+  searchOnlyCurrentWin: true,
 };
 
 export default class Properties {
@@ -61,21 +69,26 @@ export default class Properties {
 
   public colorscheme: ColorScheme;
 
+  public searchOnlyCurrentWin: boolean;
+
   constructor({
     hintchars,
     smoothscroll,
     complete,
     colorscheme,
+    searchOnlyCurrentWin,
   }: {
     hintchars?: string;
     smoothscroll?: boolean;
     complete?: string;
     colorscheme?: ColorScheme;
+    searchOnlyCurrentWin?: boolean;
   } = {}) {
     this.hintchars = hintchars || defaultValues.hintchars;
     this.smoothscroll = smoothscroll || defaultValues.smoothscroll;
     this.complete = complete || defaultValues.complete;
     this.colorscheme = colorscheme || defaultValues.colorscheme;
+    this.searchOnlyCurrentWin = searchOnlyCurrentWin || defaultValues.searchOnlyCurrentWin;
   }
 
   static fromJSON(json: PropertiesJSON): Properties {
@@ -88,6 +101,7 @@ export default class Properties {
       smoothscroll: "boolean",
       complete: "string",
       colorscheme: "string",
+      searchOnlyCurrentWin: "string",
     };
   }
 
@@ -105,6 +119,7 @@ export default class Properties {
       smoothscroll: this.smoothscroll,
       complete: this.complete,
       colorscheme: this.colorscheme,
+      searchOnlyCurrentWin: this.searchOnlyCurrentWin,
     };
   }
 }

--- a/src/shared/settings/Settings.ts
+++ b/src/shared/settings/Settings.ts
@@ -157,7 +157,8 @@ export const DefaultSettingJSONText = `{
     "hintchars": "abcdefghijklmnopqrstuvwxyz",
     "smoothscroll": false,
     "complete": "sbh",
-    "colorscheme": "system"
+    "colorscheme": "system",
+    "searchOnlyCurrentWin": true
   },
   "blacklist": [
   ]

--- a/src/shared/settings/Settings.ts
+++ b/src/shared/settings/Settings.ts
@@ -158,7 +158,7 @@ export const DefaultSettingJSONText = `{
     "smoothscroll": false,
     "complete": "sbh",
     "colorscheme": "system",
-    "searchOnlyCurrentWin": true
+    "searchOnlyCurrentWin": false
   },
   "blacklist": [
   ]

--- a/src/shared/settings/schema.json
+++ b/src/shared/settings/schema.json
@@ -52,6 +52,9 @@
         "colorscheme": {
           "type": "string",
           "enum": ["system", "light", "dark"]
+        },
+        "searchOnlyCurrentWin": {
+          "type": "boolean"
         }
       }
     },

--- a/src/shared/settings/validate.js
+++ b/src/shared/settings/validate.js
@@ -313,6 +313,26 @@ var validate = (function() {
                         }
                         var valid2 = errors === errs_2;
                       }
+                      if (valid2) {
+                        if (data1.searchOnlyCurrentWin === undefined) {
+                          valid2 = true;
+                        } else {
+                          var errs_2 = errors;
+                          if (typeof data1.searchOnlyCurrentWin !== "boolean") {
+                            validate.errors = [{
+                              keyword: 'type',
+                              dataPath: (dataPath || '') + '.properties.searchOnlyCurrentWin',
+                              schemaPath: '#/properties/properties/properties/searchOnlyCurrentWin/type',
+                              params: {
+                                type: 'boolean'
+                              },
+                              message: 'should be boolean'
+                            }];
+                            return false;
+                          }
+                          var valid2 = errors === errs_2;
+                        }
+                      }
                     }
                   }
                 }
@@ -580,6 +600,9 @@ validate.schema = {
         "colorscheme": {
           "type": "string",
           "enum": ["system", "light", "dark"]
+        },
+        "searchOnlyCurrentWin": {
+          "type": "boolean"
         }
       }
     },


### PR DESCRIPTION
As I do not use classical tabs rather than a separate window for each tab in order to get a better work-flow in a tiling window manager. I wish I had the ability to cycle through my buffer using Vim-Vixen as I was used to, when I have been using normal tabs. The addition adds the settings option to `searchOnlyCurrentWin` which restricts buffer-search to the current Window (which was the behaviour of vim-vixen before). If disabled you can access all tabs across all windows.
Once selected, the window will be focused. There still needs to be done something with the Tab-index. A quick hack is to use floats in order to address tabs with their corresponding window.  It is not a clean solution, but it currently fits my needs.
Maybe that addition could be helpful to others.