### PR TITLE
Added visual indicator to the entire window, when active, vim-vixen should interpret keystrokes (as opposed to when a textbox has focus and recieves keyboard input) #744

### DIFF
--- a/src/content/Application.ts
+++ b/src/content/Application.ts
@@ -5,6 +5,7 @@ import MarkController from "./controllers/MarkController";
 import FollowMasterController from "./controllers/FollowMasterController";
 import FollowSlaveController from "./controllers/FollowSlaveController";
 import FollowKeyController from "./controllers/FollowKeyController";
+import InputIndicator from "./InputIndicator";
 import InputDriver from "./InputDriver";
 import KeymapController from "./controllers/KeymapController";
 import AddonEnabledUseCase from "./usecases/AddonEnabledUseCase";
@@ -110,6 +111,7 @@ export default class Application {
       }
     });
 
+    new InputIndicator();
     const inputDriver = new InputDriver(window.document.body);
     inputDriver.onKey((key) => this.followKeyController.press(key));
     inputDriver.onKey((key) => this.markKeyController.press(key));

--- a/src/content/InputIndicator.ts
+++ b/src/content/InputIndicator.ts
@@ -1,0 +1,17 @@
+export default class InputIndicator {
+
+  constructor() {
+    document.addEventListener("DOMContentLoaded", this.onDetectFocus, true)
+    window.addEventListener("focus", this.onDetectFocus, true);
+    window.addEventListener("blur", this.onDetectFocus, true);
+    this.onDetectFocus();
+  }
+
+  private onDetectFocus() {
+    if (document!.activeElement!.tagName === "BODY"){
+        document.getElementById("vimvixen-console-frame")!.classList.add("vimvixen-indicate-border-active");
+    } else {
+        document.getElementById("vimvixen-console-frame")!.classList.remove("vimvixen-indicate-border-active");
+    }
+  }
+}

--- a/src/content/site-style.ts
+++ b/src/content/site-style.ts
@@ -23,4 +23,14 @@ export default `
   font-size: 12px;
   color: black;
 }
+
+.vimvixen-indicate-border-active {
+    box-sizing: border-box;
+   border: 8px solid #fa6600 !important;
+}
+
+.vimvixen-indicate-border {
+    border: 7px solid #ffffff00;
+    border-bottom: 8px solid #ffffff00;
+}
 `;


### PR DESCRIPTION
This PR may require some styling work by the vim-vixen maintainers, but it should create a better visual indicator of whether vim-vixen is 'active' or if keyboard events will be directed to some other element on the screen (such as a textbox etc).

Sorry it's not well tested, I'm not familiar with testing frontend components and don't have the time to learn, I would have held off longer but additional interest into the issue ( https://github.com/ueokande/vim-vixen/issues/744 ) has pushed me into adding a PR.