### PR TITLE
When no href value exists on a link the user selects to follow, attempt pt to click() the link to blindly trigger any JS events bound to it

### DIFF
--- a/src/content/usecases/FollowSlaveUseCase.ts
+++ b/src/content/usecases/FollowSlaveUseCase.ts
@@ -69,6 +69,7 @@ export default class FollowSlaveUseCase {
       }
       // eslint-disable-next-line no-script-url
       if (!url || url === "#" || url.toLowerCase().startsWith("javascript:")) {
+        hint.click();
         return;
       }
       await this.tabsClient.openUrl(url, openNewTab, background);


### PR DESCRIPTION
This PR will successfully trigger JS events in the following edge case:

```
<a id="clickme">Click me!</a>
<script>$("#clickme").on("click", function(){ alert(1) });</script>
```

It's reasonable to assume the user doesn't care whether or not the anchor has a valid href or triggers JS, so vim-vixen should just allow it to occur. 

