### PR TITLE
Support sendMessage to other add-ons

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -37,7 +37,7 @@
       <li><a href='./blacklist.html'>Blacklist</a></li>
       <li><a href='./search_engines.html'>Search engines</a></li>
       <li><a href='./properties.html'>Properties</a></li>
-      <li><a href='./sendmessage.html'>Properties</a></li>
+      <li><a href='./sendmessage.html'>SendMessage</a></li>
     </ul>
   </aside>
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -37,6 +37,7 @@
       <li><a href='./blacklist.html'>Blacklist</a></li>
       <li><a href='./search_engines.html'>Search engines</a></li>
       <li><a href='./properties.html'>Properties</a></li>
+      <li><a href='./sendmessage.html'>Properties</a></li>
     </ul>
   </aside>
 

--- a/docs/sendmessage.md
+++ b/docs/sendmessage.md
@@ -1,16 +1,16 @@
 ---
-title: Send Message
+title: SendMessage
 ---
 
-# Send Message
+# SendMessage
 
-Vim Vixen can send messages to other add-on.
+Vim Vixen can send messages to other add-ons to controll their functionality by keyboard, if they support. To use this feature, you need to specify `addon.sendmessage` as `type`, `extensionId` and `message` (this can be string or object) for keymaps.
 
 Note that, currently this feature can be set only when using "Use plain JSON".
 
 ## Example
 
-Following example enables to toggle collapsed state of [Tree Style Tab]()'s active tab by pressing <kbd>zc</kbd>. You can find complete API reference on [Tree Style Tab's API reference](https://github.com/piroor/treestyletab/wiki/API-for-other-addons).
+Following example enables to toggle collapsed state of [Tree Style Tab](https://addons.mozilla.org/firefox/addon/tree-style-tab/)'s active tab by pressing <kbd>zc</kbd>. This kind of API might be described in add-ons' web site, for example you can find Tree Style Tab's API reference [here](https://github.com/piroor/treestyletab/wiki/API-for-other-addons).
 
 ```json
 {
@@ -27,7 +27,5 @@ Following example enables to toggle collapsed state of [Tree Style Tab]()'s acti
 }
 ```
 
-## Misc
-
-You may want to see [Wiki page for the same function on Gesturefy](https://twitter.com/tomo_ahm/status/1297849816907575296).
+You may want to see [the Wiki page for the same feature on Gesturefy](https://twitter.com/tomo_ahm/status/1297849816907575296) for more example.
 

--- a/docs/sendmessage.md
+++ b/docs/sendmessage.md
@@ -1,0 +1,33 @@
+---
+title: Send Message
+---
+
+# Send Message
+
+Vim Vixen can send messages to other add-on.
+
+Note that, currently this feature can be set only when using "Use plain JSON".
+
+## Example
+
+Following example enables to toggle collapsed state of [Tree Style Tab]()'s active tab by pressing <kbd>zc</kbd>. You can find complete API reference on [Tree Style Tab's API reference](https://github.com/piroor/treestyletab/wiki/API-for-other-addons).
+
+```json
+{
+    "keymaps": {
+        "zc": {
+          "type": "addon.sendmessage",
+          "extensionId": "treestyletab@piro.sakura.ne.jp",
+          "message": {
+            "type": "toggle-tree-collapsed",
+            "tab": "active"
+            }
+        }
+    }
+}
+```
+
+## Misc
+
+You may want to see [Wiki page for the same function on Gesturefy](https://twitter.com/tomo_ahm/status/1297849816907575296).
+

--- a/src/content/controllers/KeymapController.ts
+++ b/src/content/controllers/KeymapController.ts
@@ -51,7 +51,8 @@ export default class KeymapController {
         case operations.ADDON_TOGGLE_ENABLED:
           return () => this.addonEnabledUseCase.toggle();
         case operations.ADDON_SENDMESSAGE:
-          return () => this.addonSendmessageUseCase.sendMessage(op.extensionId, op.message);
+          return () =>
+            this.addonSendmessageUseCase.sendMessage(op.extensionId, op.message);
         case operations.FIND_NEXT:
           return () => this.findSlaveUseCase.findNext();
         case operations.FIND_PREV:

--- a/src/content/controllers/KeymapController.ts
+++ b/src/content/controllers/KeymapController.ts
@@ -48,6 +48,10 @@ export default class KeymapController {
           return () => this.addonEnabledUseCase.disable();
         case operations.ADDON_TOGGLE_ENABLED:
           return () => this.addonEnabledUseCase.toggle();
+        case operations.ADDON_SENDMESSAGE:
+          return () => {
+            browser.runtime.sendMessage(op.extensionId, op.message);
+          };
         case operations.FIND_NEXT:
           return () => this.findSlaveUseCase.findNext();
         case operations.FIND_PREV:

--- a/src/content/controllers/KeymapController.ts
+++ b/src/content/controllers/KeymapController.ts
@@ -52,7 +52,10 @@ export default class KeymapController {
           return () => this.addonEnabledUseCase.toggle();
         case operations.ADDON_SENDMESSAGE:
           return () =>
-            this.addonSendmessageUseCase.sendMessage(op.extensionId, op.message);
+            this.addonSendmessageUseCase.sendMessage(
+              op.extensionId,
+              op.message
+            );
         case operations.FIND_NEXT:
           return () => this.findSlaveUseCase.findNext();
         case operations.FIND_PREV:

--- a/src/content/controllers/KeymapController.ts
+++ b/src/content/controllers/KeymapController.ts
@@ -2,6 +2,7 @@ import { injectable, inject } from "tsyringe";
 import * as operations from "../../shared/operations";
 import KeymapUseCase from "../usecases/KeymapUseCase";
 import AddonEnabledUseCase from "../usecases/AddonEnabledUseCase";
+import AddonSendmessageUseCase from "../usecases/AddonSendmessageUseCase";
 import FindSlaveUseCase from "../usecases/FindSlaveUseCase";
 import ScrollUseCase from "../usecases/ScrollUseCase";
 import FocusUseCase from "../usecases/FocusUseCase";
@@ -16,6 +17,7 @@ export default class KeymapController {
   constructor(
     private keymapUseCase: KeymapUseCase,
     private addonEnabledUseCase: AddonEnabledUseCase,
+    private addonSendmessageUseCase: AddonSendmessageUseCase,
     private findSlaveUseCase: FindSlaveUseCase,
     private scrollUseCase: ScrollUseCase,
     private focusUseCase: FocusUseCase,
@@ -49,9 +51,7 @@ export default class KeymapController {
         case operations.ADDON_TOGGLE_ENABLED:
           return () => this.addonEnabledUseCase.toggle();
         case operations.ADDON_SENDMESSAGE:
-          return () => {
-            browser.runtime.sendMessage(op.extensionId, op.message);
-          };
+          return () => this.addonSendmessageUseCase.sendMessage(op.extensionId, op.message);
         case operations.FIND_NEXT:
           return () => this.findSlaveUseCase.findNext();
         case operations.FIND_PREV:

--- a/src/content/usecases/AddonSendmessageUseCase.ts
+++ b/src/content/usecases/AddonSendmessageUseCase.ts
@@ -1,0 +1,15 @@
+import { injectable} from "tsyringe";
+
+
+@injectable()
+export default class AddonSendmessageUseCase {
+    constructor() { }
+
+    async sendMessage(extensionId: string, message: any) {
+        const sending = browser.runtime.sendMessage(extensionId, message);
+        sending.catch((reason: any) => {
+            throw new Error(reason);
+        });
+        return sending;
+    }
+}

--- a/src/content/usecases/AddonSendmessageUseCase.ts
+++ b/src/content/usecases/AddonSendmessageUseCase.ts
@@ -1,14 +1,16 @@
-import { injectable} from "tsyringe";
-
+import { injectable, inject } from "tsyringe";
+import ConsoleClient from "../client/ConsoleClient";
 
 @injectable()
 export default class AddonSendmessageUseCase {
-    constructor() { }
+    constructor(
+        @inject("ConsoleClient") private consoleClient: ConsoleClient
+    ) {}
 
     async sendMessage(extensionId: string, message: any) {
         const sending = browser.runtime.sendMessage(extensionId, message);
         sending.catch((reason: any) => {
-            throw new Error(reason);
+            this.consoleClient.error(`Error on sending message to ${extensionId}: ${reason}`);
         });
         return sending;
     }

--- a/src/content/usecases/AddonSendmessageUseCase.ts
+++ b/src/content/usecases/AddonSendmessageUseCase.ts
@@ -3,15 +3,15 @@ import ConsoleClient from "../client/ConsoleClient";
 
 @injectable()
 export default class AddonSendmessageUseCase {
-    constructor(
-        @inject("ConsoleClient") private consoleClient: ConsoleClient
-    ) {}
+  constructor(@inject("ConsoleClient") private consoleClient: ConsoleClient) {}
 
-    async sendMessage(extensionId: string, message: any) {
-        const sending = browser.runtime.sendMessage(extensionId, message);
-        sending.catch((reason: any) => {
-            this.consoleClient.error(`Error on sending message to ${extensionId}: ${reason}`);
-        });
-        return sending;
-    }
+  async sendMessage(extensionId: string, message: any) {
+    const sending = browser.runtime.sendMessage(extensionId, message);
+    sending.catch((reason: any) => {
+      this.consoleClient.error(
+        `Error on sending message to ${extensionId}: ${reason}`
+      );
+    });
+    return sending;
+  }
 }

--- a/src/shared/operations.ts
+++ b/src/shared/operations.ts
@@ -101,7 +101,7 @@ export interface AddonToggleEnabledOperation {
 export interface AddonSendmessageOperation {
   type: typeof ADDON_SENDMESSAGE;
   extensionId: string;
-  message: string | object;
+  message: string | Record<string, string>;
 }
 
 export interface CommandShowOperation {
@@ -438,7 +438,7 @@ export const valueOf = (o: any): Operation => {
       return {
         type: o.type,
         extensionId: o.extensionId,
-        message: o.message
+        message: o.message,
       };
     case COMMAND_SHOW_OPEN:
     case COMMAND_SHOW_TABOPEN:

--- a/src/shared/operations.ts
+++ b/src/shared/operations.ts
@@ -5,6 +5,7 @@ export const CANCEL = "cancel";
 export const ADDON_ENABLE = "addon.enable";
 export const ADDON_DISABLE = "addon.disable";
 export const ADDON_TOGGLE_ENABLED = "addon.toggle.enabled";
+export const ADDON_SENDMESSAGE = "addon.sendmessage";
 
 // Command
 export const COMMAND_SHOW = "command.show";
@@ -95,6 +96,12 @@ export interface AddonDisableOperation {
 
 export interface AddonToggleEnabledOperation {
   type: typeof ADDON_TOGGLE_ENABLED;
+}
+
+export interface AddonSendmessageOperation {
+  type: typeof ADDON_SENDMESSAGE;
+  extensionId: string;
+  message: string | object;
 }
 
 export interface CommandShowOperation {
@@ -315,6 +322,7 @@ export type Operation =
   | AddonEnableOperation
   | AddonDisableOperation
   | AddonToggleEnabledOperation
+  | AddonSendmessageOperation
   | CommandShowOperation
   | CommandShowOpenOperation
   | CommandShowTabopenOperation
@@ -409,12 +417,29 @@ const assertRequiredString = (obj: any, name: string) => {
   }
 };
 
+const assertRequiredObjectOrString = (obj: any, name: string) => {
+  if (
+    !Object.prototype.hasOwnProperty.call(obj, name) ||
+    !(typeof obj[name] === "string" || typeof obj[name] == "object")
+  ) {
+    throw new TypeError(`Missing object or string parameter: '${name}`);
+  }
+};
+
 // eslint-disable-next-line complexity, max-lines-per-function
 export const valueOf = (o: any): Operation => {
   if (!Object.prototype.hasOwnProperty.call(o, "type")) {
     throw new TypeError(`Missing 'type' field`);
   }
   switch (o.type) {
+    case ADDON_SENDMESSAGE:
+      assertRequiredString(o, "extensionId");
+      assertRequiredObjectOrString(o, "message");
+      return {
+        type: o.type,
+        extensionId: o.extensionId,
+        message: o.message
+      };
     case COMMAND_SHOW_OPEN:
     case COMMAND_SHOW_TABOPEN:
     case COMMAND_SHOW_WINOPEN:


### PR DESCRIPTION
This PR adds functionality to send messages to other add-ons, [just like Gesturefy](https://github.com/Robbendebiene/Gesturefy/wiki/Send-message-to-other-addon). I think this can make Vim-Vixen more extensible and flexible.  For me, I want to control Tree Style Tab by keyboard!