### PR TITLE
Console frame rendering fix

### DIFF
--- a/src/content/site-style.ts
+++ b/src/content/site-style.ts
@@ -9,7 +9,7 @@ export default `
   position: fixed;
   z-index: 2147483647;
   border: none;
-  background-color: unset;
+  background-color: unset !important;
   pointer-events:none;
 }
 

--- a/src/content/site-style.ts
+++ b/src/content/site-style.ts
@@ -8,7 +8,7 @@ export default `
   height: 100%;
   position: fixed;
   z-index: 2147483647;
-  border: none;
+  border: none !important;
   background-color: unset !important;
   pointer-events:none;
 }


### PR DESCRIPTION
Prevents websites from overriding the background and border of the console frame.

Fixes issues #808, #773, and #769 