### PR TITLE
Focus inputs without type

### DIFF
--- a/src/content/presenters/FocusPresenter.ts
+++ b/src/content/presenters/FocusPresenter.ts
@@ -11,7 +11,7 @@ export class FocusPresenterImpl implements FocusPresenter {
       .map((type) => `input[type=${type}]`)
       .join(",");
     const targets = window.document.querySelectorAll(
-      inputSelector + ",textarea"
+      inputSelector + ",input:not([type]),textarea"
     );
     const target = Array.from(targets).find(doms.isVisible);
     if (target instanceof HTMLInputElement) {


### PR DESCRIPTION
This addresses issue #779 .  On the example reported, the input element is missing a "type" attribute.  As per the HTML spec and Mozilla documentation, this defaults to type="text".  It's worth noting that a more spec-compliant implementation of this feature would be to use a list of input types to not match, since unknown types (eg. typos) also default to type="text".