### PR TITLE
End-of-support Firefox 68 ESR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ executors:
     docker:
       - image: circleci/node:12.14.0-stretch-browsers
     environment:
-      - FIREFOX_VERSION: "68.0esr"
-      - GECKODRIVER_VERSION: "0.24.0"
+      - FIREFOX_VERSION: "78.3.0esr"
+      - GECKODRIVER_VERSION: "0.27.0"
     working_directory: ~
 
 commands:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For usage and more detailed information, check out our [documentations][document
 
 ## Compatibility
 
-- Firefox 68 ESR
+- Firefox 78 ESR
 
 ## Copyright
 


### PR DESCRIPTION
Firefox 68 ESR is no longer supported by Mozilla, officially.  The version is end-of-life on 2020-09-22.

- [Firefox Release Calendar - MozillaWiki](https://wiki.mozilla.org/Release_Management/Calendar)

The next Vim Vixen shifts to Firefox 78 on supported browser version.