### PR TITLE
Iframe dynamic resize

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Vim vixen",
   "scripts": {
     "schema": "ajv compile -s src/shared/settings/schema.json -o src/shared/settings/validate.js",
-    "start": "webpack --mode development -w --debug --devtool inline-source-map",
+    "start": "webpack --mode development -w --devtool inline-source-map",
     "build": "NODE_ENV=production webpack --mode production --progress --devtool inline-source-map",
     "package": "yarn build && script/package",
     "lint": "eslint --ext .ts,.tsx .",

--- a/src/background/controllers/AddonEnabledController.ts
+++ b/src/background/controllers/AddonEnabledController.ts
@@ -5,7 +5,7 @@ import AddonEnabledUseCase from "../usecases/AddonEnabledUseCase";
 export default class AddonEnabledController {
   constructor(private addonEnabledUseCase: AddonEnabledUseCase) {}
 
-  indicate(enabled: boolean): Promise<any> {
+  indicate(enabled: boolean): Promise<void> {
     return this.addonEnabledUseCase.indicate(enabled);
   }
 }

--- a/src/background/controllers/CommandController.ts
+++ b/src/background/controllers/CommandController.ts
@@ -11,7 +11,7 @@ export default class CommandController {
   constructor(private commandIndicator: CommandUseCase) {}
 
   // eslint-disable-next-line complexity
-  exec(line: string): Promise<any> {
+  exec(line: string): Promise<unknown> {
     const trimmed = trimStart(line);
     const words = trimmed.split(/ +/);
     const name = words[0];

--- a/src/background/controllers/ConsoleController.ts
+++ b/src/background/controllers/ConsoleController.ts
@@ -1,0 +1,11 @@
+import { injectable } from "tsyringe";
+import ConsoleUseCase from "./ConsoleUseCase";
+
+@injectable()
+export default class ConsoleController {
+  constructor(private readonly consoleUseCase: ConsoleUseCase) {}
+
+  resize(width: number, height: number) {
+    return this.consoleUseCase.resize(width, height);
+  }
+}

--- a/src/background/controllers/ConsoleFrameClient.ts
+++ b/src/background/controllers/ConsoleFrameClient.ts
@@ -1,0 +1,15 @@
+import * as messages from "../../shared/messages";
+
+export default interface ConsoleFrameClient {
+  resize(tabId: number, width: number, height: number): Promise<void>;
+}
+
+export class ConsoleFrameClientImpl implements ConsoleFrameClient {
+  async resize(tabId: number, width: number, height: number): Promise<void> {
+    await browser.tabs.sendMessage(tabId, {
+      type: messages.CONSOLE_RESIZE,
+      width,
+      height,
+    });
+  }
+}

--- a/src/background/controllers/ConsoleUseCase.ts
+++ b/src/background/controllers/ConsoleUseCase.ts
@@ -1,0 +1,21 @@
+import { inject, injectable } from "tsyringe";
+import ConsoleFrameClient from "./ConsoleFrameClient";
+import TabPresenter from "../presenters/TabPresenter";
+
+@injectable()
+export default class ConsoleUseCase {
+  constructor(
+    @inject("TabPresenter")
+    private readonly tabPresenter: TabPresenter,
+    @inject("ConsoleFrameClient")
+    private readonly consoleFrameClient: ConsoleFrameClient
+  ) {}
+
+  async resize(width: number, height: number): Promise<void> {
+    const tabId = (await this.tabPresenter.getCurrent()).id;
+    if (typeof tabId === "undefined") {
+      return;
+    }
+    return this.consoleFrameClient.resize(tabId, width, height);
+  }
+}

--- a/src/background/controllers/FindController.ts
+++ b/src/background/controllers/FindController.ts
@@ -9,7 +9,7 @@ export default class FindController {
     return this.findUseCase.getKeyword();
   }
 
-  setKeyword(keyword: string): Promise<any> {
+  setKeyword(keyword: string): Promise<void> {
     return this.findUseCase.setKeyword(keyword);
   }
 }

--- a/src/background/controllers/MarkController.ts
+++ b/src/background/controllers/MarkController.ts
@@ -5,11 +5,11 @@ import MarkUseCase from "../usecases/MarkUseCase";
 export default class MarkController {
   constructor(private markUseCase: MarkUseCase) {}
 
-  setGlobal(key: string, x: number, y: number): Promise<any> {
+  setGlobal(key: string, x: number, y: number): Promise<void> {
     return this.markUseCase.setGlobal(key, x, y);
   }
 
-  jumpGlobal(key: string): Promise<any> {
+  jumpGlobal(key: string): Promise<void> {
     return this.markUseCase.jumpGlobal(key);
   }
 }

--- a/src/background/controllers/OperationController.ts
+++ b/src/background/controllers/OperationController.ts
@@ -11,7 +11,7 @@ export default class OperationController {
     private readonly operatorFactory: OperatorFactory
   ) {}
 
-  async exec(repeat: number, op: operations.Operation): Promise<any> {
+  async exec(repeat: number, op: operations.Operation): Promise<void> {
     await this.doOperation(repeat, op);
     if (this.repeatUseCase.isRepeatable(op)) {
       this.repeatUseCase.storeLastOperation(op);
@@ -21,7 +21,7 @@ export default class OperationController {
   private async doOperation(
     repeat: number,
     operation: operations.Operation
-  ): Promise<any> {
+  ): Promise<void> {
     const operator = this.operatorFactory.create(operation);
     for (let i = 0; i < repeat; ++i) {
       // eslint-disable-next-line no-await-in-loop

--- a/src/background/controllers/SettingController.ts
+++ b/src/background/controllers/SettingController.ts
@@ -14,7 +14,7 @@ export default class SettingController {
     return this.settingUseCase.getCached();
   }
 
-  async reload(): Promise<any> {
+  async reload(): Promise<void> {
     await this.settingUseCase.reload();
     this.contentMessageClient.broadcastSettingsChanged();
   }

--- a/src/background/di.ts
+++ b/src/background/di.ts
@@ -18,6 +18,7 @@ import { BrowserSettingRepositoryImpl } from "./repositories/BrowserSettingRepos
 import { RepeatRepositoryImpl } from "./repositories/RepeatRepository";
 import { ZoomPresenterImpl } from "./presenters/ZoomPresenter";
 import { WindowPresenterImpl } from "./presenters/WindowPresenter";
+import { ConsoleFrameClientImpl } from "./controllers/ConsoleFrameClient";
 
 container.register("LocalSettingRepository", {
   useClass: LocalSettingRepository,
@@ -41,4 +42,5 @@ container.register("TabPresenter", { useClass: TabPresenterImpl });
 container.register("WindowPresenter", { useClass: WindowPresenterImpl });
 container.register("NavigateClient", { useClass: NavigateClientImpl });
 container.register("ConsoleClient", { useClass: ConsoleClientImpl });
+container.register("ConsoleFrameClient", { useClass: ConsoleFrameClientImpl });
 container.register("OperatorFactory", { useClass: OperatorFactoryImpl });

--- a/src/background/infrastructures/ConsoleClient.ts
+++ b/src/background/infrastructures/ConsoleClient.ts
@@ -2,47 +2,47 @@ import { injectable } from "tsyringe";
 import * as messages from "../../shared/messages";
 
 export default interface ConsoleClient {
-  showCommand(tabId: number, command: string): Promise<any>;
+  showCommand(tabId: number, command: string): Promise<void>;
 
-  showFind(tabId: number): Promise<any>;
+  showFind(tabId: number): Promise<void>;
 
-  showInfo(tabId: number, message: string): Promise<any>;
+  showInfo(tabId: number, message: string): Promise<void>;
 
-  showError(tabId: number, message: string): Promise<any>;
+  showError(tabId: number, message: string): Promise<void>;
 
-  hide(tabId: number): Promise<any>;
+  hide(tabId: number): Promise<void>;
 }
 
 @injectable()
 export class ConsoleClientImpl implements ConsoleClient {
-  showCommand(tabId: number, command: string): Promise<any> {
+  showCommand(tabId: number, command: string): Promise<void> {
     return browser.tabs.sendMessage(tabId, {
       type: messages.CONSOLE_SHOW_COMMAND,
       command,
     });
   }
 
-  showFind(tabId: number): Promise<any> {
+  showFind(tabId: number): Promise<void> {
     return browser.tabs.sendMessage(tabId, {
       type: messages.CONSOLE_SHOW_FIND,
     });
   }
 
-  showInfo(tabId: number, message: string): Promise<any> {
+  showInfo(tabId: number, message: string): Promise<void> {
     return browser.tabs.sendMessage(tabId, {
       type: messages.CONSOLE_SHOW_INFO,
       text: message,
     });
   }
 
-  showError(tabId: number, message: string): Promise<any> {
+  showError(tabId: number, message: string): Promise<void> {
     return browser.tabs.sendMessage(tabId, {
       type: messages.CONSOLE_SHOW_ERROR,
       text: message,
     });
   }
 
-  hide(tabId: number): Promise<any> {
+  hide(tabId: number): Promise<void> {
     return browser.tabs.sendMessage(tabId, {
       type: messages.CONSOLE_HIDE,
     });

--- a/src/background/infrastructures/ContentMessageListener.ts
+++ b/src/background/infrastructures/ContentMessageListener.ts
@@ -9,23 +9,23 @@ import LinkController from "../controllers/LinkController";
 import OperationController from "../controllers/OperationController";
 import MarkController from "../controllers/MarkController";
 import CompletionController from "../controllers/CompletionController";
+import ConsoleController from "../controllers/ConsoleController";
 
 @injectable()
 export default class ContentMessageListener {
-  private consolePorts: { [tabId: number]: browser.runtime.Port };
+  private readonly consolePorts: { [tabId: number]: browser.runtime.Port } = {};
 
   constructor(
-    private settingController: SettingController,
-    private commandController: CommandController,
-    private completionController: CompletionController,
-    private findController: FindController,
-    private addonEnabledController: AddonEnabledController,
-    private linkController: LinkController,
-    private operationController: OperationController,
-    private markController: MarkController
-  ) {
-    this.consolePorts = {};
-  }
+    private readonly settingController: SettingController,
+    private readonly commandController: CommandController,
+    private readonly completionController: CompletionController,
+    private readonly findController: FindController,
+    private readonly addonEnabledController: AddonEnabledController,
+    private readonly linkController: LinkController,
+    private readonly operationController: OperationController,
+    private readonly markController: MarkController,
+    private readonly consoleController: ConsoleController
+  ) {}
 
   run(): void {
     browser.runtime.onMessage.addListener(
@@ -80,6 +80,8 @@ export default class ContentMessageListener {
         return this.completionController.getProperties();
       case messages.CONSOLE_ENTER_COMMAND:
         return this.onConsoleEnterCommand(message.text);
+      case messages.CONSOLE_RESIZE:
+        return this.onConsoleResize(message.width, message.height);
       case messages.SETTINGS_QUERY:
         return this.onSettingsQuery();
       case messages.FIND_GET_KEYWORD:
@@ -112,6 +114,10 @@ export default class ContentMessageListener {
 
   onConsoleEnterCommand(text: string): Promise<unknown> {
     return this.commandController.exec(text);
+  }
+
+  onConsoleResize(width: number, height: number): Promise<void> {
+    return this.consoleController.resize(width, height);
   }
 
   async onSettingsQuery(): Promise<unknown> {

--- a/src/background/infrastructures/ContentMessageListener.ts
+++ b/src/background/infrastructures/ContentMessageListener.ts
@@ -61,7 +61,7 @@ export default class ContentMessageListener {
   onMessage(
     message: messages.Message,
     senderTab: browser.tabs.Tab
-  ): Promise<any> | any {
+  ): Promise<unknown> | unknown {
     switch (message.type) {
       case messages.CONSOLE_GET_COMPLETION_TYPES:
         return this.completionController.getCompletionTypes();
@@ -110,11 +110,11 @@ export default class ContentMessageListener {
     throw new Error("unsupported message: " + message.type);
   }
 
-  onConsoleEnterCommand(text: string): Promise<any> {
+  onConsoleEnterCommand(text: string): Promise<unknown> {
     return this.commandController.exec(text);
   }
 
-  async onSettingsQuery(): Promise<any> {
+  async onSettingsQuery(): Promise<unknown> {
     return (await this.settingController.getSetting()).toJSON();
   }
 
@@ -122,11 +122,11 @@ export default class ContentMessageListener {
     return this.findController.getKeyword();
   }
 
-  onFindSetKeyword(keyword: string): Promise<any> {
+  onFindSetKeyword(keyword: string): Promise<void> {
     return this.findController.setKeyword(keyword);
   }
 
-  onAddonEnabledResponse(enabled: boolean): Promise<any> {
+  onAddonEnabledResponse(enabled: boolean): Promise<void> {
     return this.addonEnabledController.indicate(enabled);
   }
 
@@ -135,22 +135,25 @@ export default class ContentMessageListener {
     url: string,
     openerId: number,
     background: boolean
-  ): Promise<any> {
+  ): Promise<void> {
     if (newTab) {
       return this.linkController.openNewTab(url, openerId, background);
     }
     return this.linkController.openToTab(url, openerId);
   }
 
-  onBackgroundOperation(count: number, op: operations.Operation): Promise<any> {
+  onBackgroundOperation(
+    count: number,
+    op: operations.Operation
+  ): Promise<void> {
     return this.operationController.exec(count, op);
   }
 
-  onMarkSetGlobal(key: string, x: number, y: number): Promise<any> {
+  onMarkSetGlobal(key: string, x: number, y: number): Promise<void> {
     return this.markController.setGlobal(key, x, y);
   }
 
-  onMarkJumpGlobal(key: string): Promise<any> {
+  onMarkJumpGlobal(key: string): Promise<void> {
     return this.markController.jumpGlobal(key);
   }
 

--- a/src/background/repositories/FindRepository.ts
+++ b/src/background/repositories/FindRepository.ts
@@ -15,7 +15,7 @@ export default class FindRepository {
     return Promise.resolve(this.cache.get(FIND_KEYWORD_KEY));
   }
 
-  setKeyword(keyword: string): Promise<any> {
+  setKeyword(keyword: string): Promise<void> {
     this.cache.set(FIND_KEYWORD_KEY, keyword);
     return Promise.resolve();
   }

--- a/src/background/repositories/MarkRepository.ts
+++ b/src/background/repositories/MarkRepository.ts
@@ -22,7 +22,7 @@ export default class MarkRepository {
     return Promise.resolve(mark);
   }
 
-  setMark(key: string, mark: GlobalMark): Promise<any> {
+  setMark(key: string, mark: GlobalMark): Promise<void> {
     const marks = this.getOrEmptyMarks();
     marks[key] = { tabId: mark.tabId, url: mark.url, x: mark.x, y: mark.y };
     this.cache.set(MARK_KEY, marks);

--- a/src/background/usecases/CommandUseCase.ts
+++ b/src/background/usecases/CommandUseCase.ts
@@ -58,7 +58,7 @@ export default class CommandUseCase {
   }
 
   // eslint-disable-next-line max-statements
-  async buffer(keywords: string): Promise<any> {
+  async buffer(keywords: string): Promise<void> {
     if (keywords.length === 0) {
       return;
     }
@@ -95,7 +95,7 @@ export default class CommandUseCase {
     return this.tabPresenter.select(tabs[0].id as number);
   }
 
-  async bdelete(force: boolean, keywords: string): Promise<any> {
+  async bdelete(force: boolean, keywords: string): Promise<void> {
     const excludePinned = !force;
     const tabs = await this.tabPresenter.getByKeyword(keywords, excludePinned);
     if (tabs.length === 0) {
@@ -106,32 +106,32 @@ export default class CommandUseCase {
     return this.tabPresenter.remove([tabs[0].id as number]);
   }
 
-  async bdeletes(force: boolean, keywords: string): Promise<any> {
+  async bdeletes(force: boolean, keywords: string): Promise<void> {
     const excludePinned = !force;
     const tabs = await this.tabPresenter.getByKeyword(keywords, excludePinned);
     const ids = tabs.map((tab) => tab.id as number);
     return this.tabPresenter.remove(ids);
   }
 
-  async quit(): Promise<any> {
+  async quit(): Promise<void> {
     const tab = await this.tabPresenter.getCurrent();
     return this.tabPresenter.remove([tab.id as number]);
   }
 
-  async quitAll(): Promise<any> {
+  async quitAll(): Promise<void> {
     const tabs = await this.tabPresenter.getAll();
     const ids = tabs.map((tab) => tab.id as number);
     this.tabPresenter.remove(ids);
   }
 
-  async addbookmark(title: string): Promise<any> {
+  async addbookmark(title: string): Promise<void> {
     const tab = await this.tabPresenter.getCurrent();
     const item = await this.bookmarkRepository.create(title, tab.url as string);
     const message = "Saved current page: " + item.url;
     return this.consoleClient.showInfo(tab.id as number, message);
   }
 
-  async set(keywords: string): Promise<any> {
+  async set(keywords: string): Promise<void> {
     if (keywords.length === 0) {
       return;
     }
@@ -145,7 +145,7 @@ export default class CommandUseCase {
     return this.helpPresenter.open();
   }
 
-  private async urlOrSearch(keywords: string): Promise<any> {
+  private async urlOrSearch(keywords: string): Promise<string> {
     const settings = await this.cachedSettingRepository.get();
     return urls.searchUrl(keywords, settings.search);
   }

--- a/src/background/usecases/FindUseCase.ts
+++ b/src/background/usecases/FindUseCase.ts
@@ -9,7 +9,7 @@ export default class FindUseCase {
     return this.findRepository.getKeyword();
   }
 
-  setKeyword(keyword: string): Promise<any> {
+  setKeyword(keyword: string): Promise<void> {
     return this.findRepository.setKeyword(keyword);
   }
 }

--- a/src/background/usecases/LinkUseCase.ts
+++ b/src/background/usecases/LinkUseCase.ts
@@ -5,15 +5,15 @@ import TabPresenter from "../presenters/TabPresenter";
 export default class LinkUseCase {
   constructor(@inject("TabPresenter") private tabPresenter: TabPresenter) {}
 
-  openToTab(url: string, tabId: number): Promise<any> {
-    return this.tabPresenter.open(url, tabId);
+  async openToTab(url: string, tabId: number): Promise<void> {
+    await this.tabPresenter.open(url, tabId);
   }
 
   async openNewTab(
     url: string,
     openerId: number,
     background: boolean
-  ): Promise<any> {
+  ): Promise<void> {
     const properties: any = { active: !background };
 
     const platform = await browser.runtime.getPlatformInfo();
@@ -22,6 +22,6 @@ export default class LinkUseCase {
       properties.openerTabId = openerId;
     }
 
-    return this.tabPresenter.create(url, properties);
+    await this.tabPresenter.create(url, properties);
   }
 }

--- a/src/background/usecases/MarkUseCase.ts
+++ b/src/background/usecases/MarkUseCase.ts
@@ -15,13 +15,13 @@ export default class MarkUseCase {
     private readonly contentMessageClient: ContentMessageClient
   ) {}
 
-  async setGlobal(key: string, x: number, y: number): Promise<any> {
+  async setGlobal(key: string, x: number, y: number): Promise<void> {
     const tab = await this.tabPresenter.getCurrent();
     const mark = { tabId: tab.id as number, url: tab.url as string, x, y };
     return this.markRepository.setMark(key, mark);
   }
 
-  async jumpGlobal(key: string): Promise<any> {
+  async jumpGlobal(key: string): Promise<void> {
     const current = await this.tabPresenter.getCurrent();
 
     const mark = await this.markRepository.getMark(key);

--- a/src/console/clients/ConsoleFrameClient.ts
+++ b/src/console/clients/ConsoleFrameClient.ts
@@ -1,0 +1,11 @@
+import * as messages from "../../shared/messages";
+
+export default class ConsoleFrameClient {
+  async resize(width: number, height: number): Promise<void> {
+    await browser.runtime.sendMessage({
+      type: messages.CONSOLE_RESIZE,
+      width,
+      height,
+    });
+  }
+}

--- a/src/console/components/Console.tsx
+++ b/src/console/components/Console.tsx
@@ -13,6 +13,7 @@ import ColorScheme from "../../shared/ColorScheme";
 import { LightTheme, DarkTheme } from "./Theme";
 import styled from "./Theme";
 import { ThemeProvider } from "styled-components";
+import ConsoleFrameClient from "../clients/ConsoleFrameClient";
 
 const ConsoleWrapper = styled.div`
   border-top: 1px solid gray;
@@ -30,6 +31,7 @@ class Console extends React.Component<Props> {
   private input: React.RefObject<Input>;
 
   private commandLineParser: CommandLineParser = new CommandLineParser();
+  private consoleFrameClient = new ConsoleFrameClient();
 
   constructor(props: Props) {
     super(props);
@@ -130,6 +132,12 @@ class Console extends React.Component<Props> {
     } else if (prevProps.mode !== "find" && this.props.mode === "find") {
       this.focus();
     }
+
+    const {
+      scrollWidth: width,
+      scrollHeight: height,
+    } = document.getElementById("vimvixen-console")!;
+    this.consoleFrameClient.resize(width, height);
   }
 
   render() {

--- a/src/content/Application.ts
+++ b/src/content/Application.ts
@@ -107,6 +107,8 @@ export default class Application {
           return this.navigateController.openLinkNext(msg);
         case messages.NAVIGATE_LINK_PREV:
           return this.navigateController.openLinkPrev(msg);
+        case messages.CONSOLE_RESIZE:
+          return this.consoleFrameController.resize(msg);
       }
     });
 

--- a/src/content/controllers/ConsoleFrameController.ts
+++ b/src/content/controllers/ConsoleFrameController.ts
@@ -9,4 +9,8 @@ export default class ConsoleFrameController {
   unfocus(_message: messages.Message) {
     this.consoleFrameUseCase.unfocus();
   }
+
+  resize(message: messages.ConsoleResizeMessage) {
+    this.consoleFrameUseCase.resize(message.width, message.height);
+  }
 }

--- a/src/content/presenters/ConsoleFramePresenter.ts
+++ b/src/content/presenters/ConsoleFramePresenter.ts
@@ -2,6 +2,8 @@ export default interface ConsoleFramePresenter {
   initialize(): void;
 
   blur(): void;
+
+  resize(width: number, height: number): void;
 }
 
 export class ConsoleFramePresenterImpl implements ConsoleFramePresenter {
@@ -19,5 +21,13 @@ export class ConsoleFramePresenterImpl implements ConsoleFramePresenter {
       throw new Error("console frame not created");
     }
     ele.blur();
+  }
+
+  resize(_width: number, height: number): void {
+    const ele = document.getElementById("vimvixen-console-frame");
+    if (!ele) {
+      return;
+    }
+    ele.style.height = `${height}px`;
   }
 }

--- a/src/content/site-style.ts
+++ b/src/content/site-style.ts
@@ -5,7 +5,6 @@ export default `
   bottom: 0;
   left: 0;
   width: 100%;
-  height: 100%;
   position: fixed;
   z-index: 2147483647;
   border: none !important;

--- a/src/content/usecases/ConsoleFrameUseCase.ts
+++ b/src/content/usecases/ConsoleFrameUseCase.ts
@@ -12,4 +12,8 @@ export default class ConsoleFrameUseCase {
     window.focus();
     this.consoleFramePresenter.blur();
   }
+
+  resize(width: number, height: number) {
+    this.consoleFramePresenter.resize(width, height);
+  }
 }

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -19,6 +19,7 @@ export const CONSOLE_REQUEST_BOOKMARKS = "console.request.bookmarks";
 export const CONSOLE_REQUEST_HISTORY = "console.request.history";
 export const CONSOLE_REQUEST_TABS = "console.request.tabs";
 export const CONSOLE_GET_PROPERTIES = "console.get.properties";
+export const CONSOLE_RESIZE = "console.resize";
 
 export const FOLLOW_START = "follow.start";
 export const FOLLOW_REQUEST_COUNT_TARGETS = "follow.request.count.targets";
@@ -125,6 +126,12 @@ export interface ConsoleRequestTabsMessage {
 
 export interface ConsoleGetPropertiesMessage {
   type: typeof CONSOLE_GET_PROPERTIES;
+}
+
+export interface ConsoleResizeMessage {
+  type: typeof CONSOLE_RESIZE;
+  width: number;
+  height: number;
 }
 
 export type ConsoleRequestTabsResponse = {
@@ -301,6 +308,7 @@ export type Message =
   | ConsoleRequestHistoryMessage
   | ConsoleRequestTabsMessage
   | ConsoleGetPropertiesMessage
+  | ConsoleResizeMessage
   | ConsoleGetCompletionTypesMessage
   | ConsoleRequestSearchEnginesMessage
   | FollowStartMessage
@@ -363,11 +371,12 @@ export const valueOf = (o: any): Message => {
     case SETTINGS_CHANGED:
     case SETTINGS_QUERY:
     case CONSOLE_FRAME_MESSAGE:
+    case CONSOLE_RESIZE:
     case NAVIGATE_HISTORY_NEXT:
     case NAVIGATE_HISTORY_PREV:
     case NAVIGATE_LINK_NEXT:
     case NAVIGATE_LINK_PREV:
       return o;
   }
-  throw new Error("unknown operation type: " + o.type);
+  throw new Error("unknown message type: " + o.type);
 };


### PR DESCRIPTION
close  #1002

Injected iframe to the page is now resized dynamically. 

Transparent iframe covering on the whole page used to be inserted before.  Although the iframe's style has `background-color: unset !important`, the page's CSS can overwrite it, and a user saw just a white page.

This change makes iframe follow the content in the console, and it never covers the whole page.