### PR TITLE
Hide console to focus main window after find executed

### DIFF
--- a/src/console/components/FindPrompt.tsx
+++ b/src/console/components/FindPrompt.tsx
@@ -25,6 +25,7 @@ const FindPrompt: React.FC = () => {
 
     const value = (e.target as HTMLInputElement).value;
     execFind(value === "" ? undefined : value);
+    hide();
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {


### PR DESCRIPTION
After error message "Pattern not found: foo" is shown on find mode, the focus losses from the top window.  User cannot do any operation by the keyboard.  This change fixes the focus issue.