### PR TITLE
Toggle reader view

### DIFF
--- a/e2e/tab.test.ts
+++ b/e2e/tab.test.ts
@@ -107,6 +107,20 @@ describe("tab test", () => {
     assert.strictEqual(current[0].pinned, true);
   });
 
+  it("switches to reader view", async () => {
+    await browser.tabs.update(tabs[0].id, { active: true });
+    const page = await Page.currentContext(webdriver);
+    await page.sendKeys("g", "r");
+
+    // Unable to switch to reader view, but an error message occurs
+    const console = await page.getConsole();
+    const errorMessage = await console.getErrorMessage();
+    assert.strictEqual(
+      errorMessage,
+      "The specified tab cannot be placed into reader mode."
+    );
+  });
+
   it("selects previous tab by K", async () => {
     await browser.tabs.update(tabs[2].id, { active: true });
     const page = await Page.currentContext(webdriver);

--- a/src/@types/web-ext-api/index.d.ts
+++ b/src/@types/web-ext-api/index.d.ts
@@ -1,3 +1,7 @@
+declare namespace browser.tabs {
+  function toggleReaderMode(tabId?: number): Promise<void>;
+}
+
 declare namespace browser.browserSettings.homepageOverride {
   type BrowserSettings = {
     value: string;

--- a/src/background/operators/impls/TabOperatorFactoryChain.ts
+++ b/src/background/operators/impls/TabOperatorFactoryChain.ts
@@ -16,6 +16,7 @@ import PinTabOperator from "./PinTabOperator";
 import UnpinTabOperator from "./UnpinTabOperator";
 import TogglePinnedTabOperator from "./TogglePinnedTabOperator";
 import DuplicateTabOperator from "./DuplicateTabOperator";
+import ToggleReaderOperator from "./ToggleReaderOperator";
 
 @injectable()
 export default class TabOperatorFactoryChain implements OperatorFactoryChain {
@@ -58,6 +59,8 @@ export default class TabOperatorFactoryChain implements OperatorFactoryChain {
         return new TogglePinnedTabOperator(this.tabPresenter);
       case operations.TAB_DUPLICATE:
         return new DuplicateTabOperator(this.tabPresenter);
+      case operations.TAB_TOGGLE_READER:
+        return new ToggleReaderOperator(this.tabPresenter);
     }
     return null;
   }

--- a/src/background/operators/impls/ToggleReaderOperator.ts
+++ b/src/background/operators/impls/ToggleReaderOperator.ts
@@ -1,0 +1,11 @@
+import Operator from "../Operator";
+import TabPresenter from "../../presenters/TabPresenter";
+
+export default class ToggleReaderOperator implements Operator {
+  constructor(private readonly tabPresenter: TabPresenter) {}
+
+  async run(): Promise<void> {
+    const tab = await this.tabPresenter.getCurrent();
+    return this.tabPresenter.toggleReaderMode(tab.id as number);
+  }
+}

--- a/src/background/presenters/TabPresenter.ts
+++ b/src/background/presenters/TabPresenter.ts
@@ -47,6 +47,8 @@ export default interface TabPresenter {
   onSelected(
     listener: (arg: { tabId: number; windowId: number }) => void
   ): void;
+
+  toggleReaderMode(tabId: number): Promise<void>;
 }
 
 export class TabPresenterImpl implements TabPresenter {
@@ -151,6 +153,10 @@ export class TabPresenterImpl implements TabPresenter {
     listener: (arg: { tabId: number; windowId: number }) => void
   ): void {
     browser.tabs.onActivated.addListener(listener);
+  }
+
+  toggleReaderMode(tabId: number): Promise<void> {
+    return browser.tabs.toggleReaderMode(tabId);
   }
 }
 

--- a/src/settings/keymaps.ts
+++ b/src/settings/keymaps.ts
@@ -31,6 +31,7 @@ const fields = [
     ['tabs.reload?{"cache":true}', "Reload with no caches"],
     ["tabs.pin.toggle", "Toggle pinned state"],
     ["tabs.duplicate", "Duplicate a tab"],
+    ["tabs.reader.toggle", "Reader view"],
   ],
   [
     ['follow.start?{"newTab":false,"background":false}', "Follow a link"],

--- a/src/shared/operations.ts
+++ b/src/shared/operations.ts
@@ -56,6 +56,7 @@ export const TAB_PIN = "tabs.pin";
 export const TAB_UNPIN = "tabs.unpin";
 export const TAB_TOGGLE_PINNED = "tabs.pin.toggle";
 export const TAB_DUPLICATE = "tabs.duplicate";
+export const TAB_TOGGLE_READER = "tabs.reader.toggle";
 
 // Zooms
 export const ZOOM_IN = "zoom.in";
@@ -257,6 +258,10 @@ export interface TabDuplicateOperation {
   type: typeof TAB_DUPLICATE;
 }
 
+export interface TabToggleReaderOperation {
+  type: typeof TAB_TOGGLE_READER;
+}
+
 export interface ZoomInOperation {
   type: typeof ZOOM_IN;
 }
@@ -352,6 +357,7 @@ export type Operation =
   | TabUnpinOperation
   | TabTogglePinnedOperation
   | TabDuplicateOperation
+  | TabToggleReaderOperation
   | ZoomInOperation
   | ZoomOutOperation
   | ZoomNeutralOperation
@@ -506,6 +512,7 @@ export const valueOf = (o: any): Operation => {
     case TAB_UNPIN:
     case TAB_TOGGLE_PINNED:
     case TAB_DUPLICATE:
+    case TAB_TOGGLE_READER:
     case ZOOM_IN:
     case ZOOM_OUT:
     case ZOOM_NEUTRAL:

--- a/src/shared/settings/Settings.ts
+++ b/src/shared/settings/Settings.ts
@@ -133,6 +133,7 @@ export const DefaultSettingJSONText = `{
     "gf": { "type": "page.source" },
     "gh": { "type": "page.home" },
     "gH": { "type": "page.home", "newTab": true },
+    "gr": { "type": "tabs.reader.toggle" },
     "y": { "type": "urls.yank" },
     "p": { "type": "urls.paste", "newTab": false },
     "P": { "type": "urls.paste", "newTab": true },


### PR DESCRIPTION
close  #266

Switching to a [reader view] is now avaiable by <kbd>g</kbd><kbd>r</kbd> by default key settings.  For current users, this feature is enabled by adding the following key-map into your settings:

```json
    "gr": { "type": "tabs.reader.toggle" },
```

:warning: **The add-on does not work on the reader view, and it cannot be possible to switch back.** This is a limitation on WebExtensions (see #180).

 
[reader view]: https://support.mozilla.org/en-US/kb/firefox-reader-view-clutter-free-web-pages