### PR TITLE
Improve an error message on invalid settings

### DIFF
--- a/src/background/presenters/Notifier.ts
+++ b/src/background/presenters/Notifier.ts
@@ -4,7 +4,7 @@ const NOTIFICATION_ID_INVALID_SETTINGS = "vimvixen-update-invalid-settings";
 export default interface Notifier {
   notifyUpdated(version: string, onclick: () => void): Promise<void>;
 
-  notifyInvalidSettings(onclick: () => void): Promise<void>;
+  notifyInvalidSettings(error: Error, onclick: () => void): Promise<void>;
 }
 
 export class NotifierImpl implements NotifierImpl {
@@ -29,11 +29,13 @@ export class NotifierImpl implements NotifierImpl {
     });
   }
 
-  async notifyInvalidSettings(onclick: () => void): Promise<void> {
+  async notifyInvalidSettings(
+    error: Error,
+    onclick: () => void
+  ): Promise<void> {
     const title = `Loading settings failed`;
     // eslint-disable-next-line max-len
-    const message =
-      "The default settings are used due to the last saved settings is invalid.  Check your current settings from the add-on preference";
+    const message = `The default settings are used due to the last saved settings is invalid.  Check your current settings from the add-on preference: ${error.message}`;
 
     const listener = (id: string) => {
       if (id !== NOTIFICATION_ID_INVALID_SETTINGS) {

--- a/src/background/usecases/SettingUseCase.ts
+++ b/src/background/usecases/SettingUseCase.ts
@@ -54,7 +54,7 @@ export default class SettingUseCase {
 
   private showUnableToLoad(e: Error) {
     console.error("unable to load settings", e);
-    this.notifier.notifyInvalidSettings(() => {
+    this.notifier.notifyInvalidSettings(e, () => {
       browser.runtime.openOptionsPage();
     });
   }

--- a/test/background/usecases/SettingUseCase.test.ts
+++ b/test/background/usecases/SettingUseCase.test.ts
@@ -38,7 +38,7 @@ class MockCachedSettingRepository implements CachedSettingRepository {
 }
 
 class NopNotifier implements Notifier {
-  notifyInvalidSettings(_onclick: () => void): Promise<void> {
+  notifyInvalidSettings(_error: Error, _onclick: () => void): Promise<void> {
     return Promise.resolve();
   }
 


### PR DESCRIPTION
This change is an improvement when the settings is invalid to identify error cause.  This issue is reported in #722, but it is commonly can be resolved by restart the browser or clear settings.  The issue can still  occurs available when the add-on is updated.