### PR TITLE
Fix that follow works improperly with SPA

### DIFF
--- a/src/content/usecases/FollowSlaveUseCase.ts
+++ b/src/content/usecases/FollowSlaveUseCase.ts
@@ -68,7 +68,12 @@ export default class FollowSlaveUseCase {
         openNewTab = true;
       }
       // eslint-disable-next-line no-script-url
-      if (!url || url === "#" || url.toLowerCase().startsWith("javascript:")) {
+      if (
+        !newTab ||
+        !url ||
+        url === "#" ||
+        url.toLowerCase().startsWith("javascript:")
+      ) {
         hint.click();
         return;
       }


### PR DESCRIPTION
Now, when not opened in a new tab, follow simulates a click, which works properly in SPA.

This fixes #739.