### PR TITLE
Await fetching completions done completely

### DIFF
--- a/e2e/completion.test.ts
+++ b/e2e/completion.test.ts
@@ -41,11 +41,13 @@ describe("general completion test", () => {
     const console = await page.showConsole();
     await console.inputKeys("b");
 
-    const groups = await console.getCompletions();
-    const items = groups[0].items;
-    assert.ok(items[0].text.startsWith("buffer"));
-    assert.ok(items[1].text.startsWith("bdelete"));
-    assert.ok(items[2].text.startsWith("bdeletes"));
+    await eventually(async () => {
+      const groups = await console.getCompletions();
+      const items = groups[0].items;
+      assert.ok(items[0].text.startsWith("buffer"));
+      assert.ok(items[1].text.startsWith("bdelete"));
+      assert.ok(items[2].text.startsWith("bdeletes"));
+    });
   });
 
   // > byffer

--- a/src/console/App.tsx
+++ b/src/console/App.tsx
@@ -1,0 +1,51 @@
+import * as messages from "../shared/messages";
+import Console from "./components/Console";
+import React from "react";
+import {
+  useCommandMode,
+  useFindMode,
+  useInfoMessage,
+  useErrorMessage,
+  useHide,
+} from "./app/hooks";
+
+const App: React.FC = () => {
+  const hide = useHide();
+  const { show: showCommand } = useCommandMode();
+  const { show: showFind } = useFindMode();
+  const { show: showError } = useErrorMessage();
+  const { show: showInfo } = useInfoMessage();
+
+  React.useEffect(() => {
+    const onMessage = async (message: any): Promise<any> => {
+      const msg = messages.valueOf(message);
+      switch (msg.type) {
+        case messages.CONSOLE_SHOW_COMMAND:
+          showCommand(msg.command);
+          break;
+        case messages.CONSOLE_SHOW_FIND:
+          showFind();
+          break;
+        case messages.CONSOLE_SHOW_ERROR:
+          showError(msg.text);
+          break;
+        case messages.CONSOLE_SHOW_INFO:
+          showInfo(msg.text);
+          break;
+        case messages.CONSOLE_HIDE:
+          hide();
+          break;
+      }
+    };
+
+    browser.runtime.onMessage.addListener(onMessage);
+    const port = browser.runtime.connect(undefined, {
+      name: "vimvixen-console",
+    });
+    port.onMessage.addListener(onMessage);
+  }, []);
+
+  return <Console />;
+};
+
+export default App;

--- a/src/console/Completions.ts
+++ b/src/console/Completions.ts
@@ -1,9 +1,9 @@
 type Completions = {
   readonly name: string;
   readonly items: {
-    readonly caption?: string;
-    readonly content?: string;
-    readonly url?: string;
+    readonly primary?: string;
+    readonly secondary?: string;
+    readonly value?: string;
     readonly icon?: string;
   }[];
 }[];

--- a/src/console/completion/actions.ts
+++ b/src/console/completion/actions.ts
@@ -1,16 +1,9 @@
-import CompletionType from "../../shared/CompletionType";
 import Completions from "../Completions";
 
-export const INIT_COMPLETIONS = "reset.completions";
 export const SET_COMPLETION_SOURCE = "set.completion.source";
 export const SET_COMPLETIONS = "set.completions";
 export const COMPLETION_NEXT = "completion.next";
 export const COMPLETION_PREV = "completion.prev";
-
-export interface InitCompletionAction {
-  type: typeof INIT_COMPLETIONS;
-  completionTypes: CompletionType[];
-}
 
 export interface SetCompletionSourceAction {
   type: typeof SET_COMPLETION_SOURCE;
@@ -31,20 +24,11 @@ export interface CompletionPrevAction {
 }
 
 export type CompletionAction =
-  | InitCompletionAction
   | SetCompletionSourceAction
   | SetCompletionsAction
   | CompletionNextAction
   | CompletionPrevAction;
 
-export const initCompletion = (
-  completionTypes: CompletionType[]
-): InitCompletionAction => {
-  return {
-    type: INIT_COMPLETIONS,
-    completionTypes,
-  };
-};
 export const setCompletionSource = (
   query: string
 ): SetCompletionSourceAction => {

--- a/src/console/completion/hooks.ts
+++ b/src/console/completion/hooks.ts
@@ -74,9 +74,9 @@ const getCommandCompletions = async (query: string): Promise<Completions> => {
   const items = Object.entries(commandDocs)
     .filter(([name]) => name.startsWith(query))
     .map(([name, doc]) => ({
-      caption: name,
-      content: name,
-      url: doc,
+      primary: name,
+      secondary: doc,
+      value: name,
     }));
   return [
     {
@@ -102,8 +102,8 @@ const getOpenCompletions = async (
         completions.push({
           name: "Search Engines",
           items: items.map((key) => ({
-            caption: key.title,
-            content: command + " " + key.title,
+            primary: key.title,
+            value: command + " " + key.title,
           })),
         });
         break;
@@ -116,9 +116,9 @@ const getOpenCompletions = async (
         completions.push({
           name: "History",
           items: items.map((item) => ({
-            caption: item.title,
-            content: command + " " + item.url,
-            url: item.url,
+            primary: item.title,
+            secondary: item.url,
+            value: command + " " + item.url,
           })),
         });
         break;
@@ -131,9 +131,9 @@ const getOpenCompletions = async (
         completions.push({
           name: "Bookmarks",
           items: items.map((item) => ({
-            caption: item.title,
-            content: command + " " + item.url,
-            url: item.url,
+            primary: item.title,
+            secondary: item.url,
+            value: command + " " + item.url,
           })),
         });
         break;
@@ -157,11 +157,11 @@ export const getTabCompletions = async (
     {
       name: "Buffers",
       items: items.map((item) => ({
-        content: command + " " + item.url,
-        caption: `${item.index}: ${
+        primary: `${item.index}: ${
           item.flag != TabFlag.None ? item.flag : " "
         } ${item.title}`,
-        url: item.url,
+        secondary: item.url,
+        value: command + " " + item.url,
         icon: item.faviconUrl,
       })),
     },
@@ -179,28 +179,28 @@ export const getPropertyCompletions = async (
       if (item.type === "boolean") {
         return [
           {
-            caption: item.name,
-            content: command + " " + item.name,
-            url: "Enable " + desc,
+            primary: item.name,
+            secondary: "Enable " + desc,
+            value: command + " " + item.name,
           },
           {
-            caption: "no" + item.name,
-            content: command + " no" + item.name,
-            url: "Disable " + desc,
+            primary: "no" + item.name,
+            secondary: "Disable " + desc,
+            value: command + " no" + item.name,
           },
         ];
       } else {
         return [
           {
-            caption: item.name,
-            content: command + " " + item.name,
-            url: "Set " + desc,
+            primary: item.name,
+            secondary: "Set " + desc,
+            value: command + " " + item.name,
           },
         ];
       }
     })
     .reduce((acc, val) => acc.concat(val), [])
-    .filter((item) => item.caption.startsWith(query));
+    .filter((item) => item.primary.startsWith(query));
   return [{ name: "Properties", items }];
 };
 
@@ -308,7 +308,7 @@ export const useSelectCompletion = () => {
       return state.completionSource;
     }
     const items = state.completions.map((g) => g.items).flat();
-    return items[state.select]?.content || "";
+    return items[state.select]?.value || "";
   }, [state.completionSource, state.select]);
 
   return {

--- a/src/console/completion/hooks.ts
+++ b/src/console/completion/hooks.ts
@@ -170,15 +170,11 @@ export const getPropertyCompletions = async (
   return [{ name: "Properties", items }];
 };
 
-export const useCompletions = () => {
+export const useCompletions = (source: string) => {
   const state = React.useContext(CompletionStateContext);
   const dispatch = React.useContext(CompletionDispatchContext);
   const commandLineParser = React.useMemo(() => new CommandLineParser(), []);
   const [completionTypes] = useGetCompletionTypes();
-
-  const updateCompletions = React.useCallback((source: string) => {
-    dispatch(actions.setCompletionSource(source));
-  }, []);
 
   const queryCompletions = React.useCallback(
     (text: string, completionTypes: CompletionType[]) => {
@@ -233,16 +229,15 @@ export const useCompletions = () => {
   );
 
   React.useEffect(() => {
+    dispatch(actions.setCompletionSource(source));
+
     if (typeof completionTypes === "undefined") {
       return;
     }
-    queryCompletions(state.completionSource, completionTypes);
-  }, [state.completionSource, completionTypes]);
+    queryCompletions(source, completionTypes);
+  }, [source, completionTypes]);
 
-  return {
-    completions: state.completions,
-    updateCompletions,
-  };
+  return { completions: state.completions };
 };
 
 export const useSelectCompletion = () => {

--- a/src/console/completion/hooks.ts
+++ b/src/console/completion/hooks.ts
@@ -175,6 +175,7 @@ export const useCompletions = (source: string) => {
   const dispatch = React.useContext(CompletionDispatchContext);
   const commandLineParser = React.useMemo(() => new CommandLineParser(), []);
   const [completionTypes] = useGetCompletionTypes();
+  const [loading, setLoading] = React.useState(false);
 
   const queryCompletions = React.useCallback(
     (text: string, completionTypes: CompletionType[]) => {
@@ -192,40 +193,57 @@ export const useCompletions = (source: string) => {
             return;
           }
         }
+
+        setLoading(true);
         switch (cmd?.command) {
           case Command.Open:
           case Command.TabOpen:
           case Command.WindowOpen:
             getOpenCompletions(cmd.command, cmd.args, completionTypes).then(
-              (completions) => dispatch(actions.setCompletions(completions))
+              (completions) => {
+                dispatch(actions.setCompletions(completions));
+                setLoading(false);
+              }
             );
             break;
           case Command.Buffer:
             getTabCompletions(cmd.command, cmd.args, false).then(
-              (completions) => dispatch(actions.setCompletions(completions))
+              (completions) => {
+                dispatch(actions.setCompletions(completions));
+                setLoading(false);
+              }
             );
             break;
           case Command.BufferDelete:
           case Command.BuffersDelete:
-            getTabCompletions(cmd.command, cmd.args, true).then((completions) =>
-              dispatch(actions.setCompletions(completions))
+            getTabCompletions(cmd.command, cmd.args, true).then(
+              (completions) => {
+                dispatch(actions.setCompletions(completions));
+                setLoading(false);
+              }
             );
             break;
           case Command.BufferDeleteForce:
           case Command.BuffersDeleteForce:
             getTabCompletions(cmd.command, cmd.args, false).then(
-              (completions) => dispatch(actions.setCompletions(completions))
+              (completions) => {
+                dispatch(actions.setCompletions(completions));
+                setLoading(false);
+              }
             );
             break;
           case Command.Set:
-            getPropertyCompletions(cmd.command, cmd.args).then((completions) =>
-              dispatch(actions.setCompletions(completions))
+            getPropertyCompletions(cmd.command, cmd.args).then(
+              (completions) => {
+                dispatch(actions.setCompletions(completions));
+                setLoading(false);
+              }
             );
             break;
         }
       }
     },
-    [dispatch]
+    [dispatch, source]
   );
 
   React.useEffect(() => {
@@ -237,7 +255,7 @@ export const useCompletions = (source: string) => {
     queryCompletions(source, completionTypes);
   }, [source, completionTypes]);
 
-  return { completions: state.completions };
+  return { completions: state.completions, loading };
 };
 
 export const useSelectCompletion = () => {
@@ -257,7 +275,7 @@ export const useSelectCompletion = () => {
     }
     const items = state.completions.map((g) => g.items).flat();
     return items[state.select]?.value || "";
-  }, [state.completionSource, state.select]);
+  }, [state.completionSource, state.select, state.completions]);
 
   return {
     select: state.select,

--- a/src/console/completion/hooks.ts
+++ b/src/console/completion/hooks.ts
@@ -36,41 +36,6 @@ const propertyDocs: { [key: string]: string } = {
 
 const completionClient = new CompletionClient();
 
-const useDelayedCallback = <T extends unknown, U extends unknown>(
-  callback: (arg1: T, arg2: U) => void,
-  timeout: number
-) => {
-  const [timer, setTimer] = React.useState<
-    ReturnType<typeof setTimeout> | undefined
-  >();
-  const [enabled, setEnabled] = React.useState(false);
-
-  const enableDelay = React.useCallback(() => {
-    setEnabled(true);
-  }, [setEnabled]);
-
-  const delayedCallback = React.useCallback(
-    (arg1: T, arg2: U) => {
-      if (enabled) {
-        if (typeof timer !== "undefined") {
-          clearTimeout(timer);
-        }
-        const id = setTimeout(() => {
-          callback(arg1, arg2);
-          clearTimeout(timer!);
-          setTimer(undefined);
-        }, timeout);
-        setTimer(id);
-      } else {
-        callback(arg1, arg2);
-      }
-    },
-    [enabled, timer]
-  );
-
-  return { enableDelay, delayedCallback };
-};
-
 const getCommandCompletions = async (query: string): Promise<Completions> => {
   const items = Object.entries(commandDocs)
     .filter(([name]) => name.startsWith(query))
@@ -215,60 +180,56 @@ export const useCompletions = () => {
     dispatch(actions.setCompletionSource(source));
   }, []);
 
-  const { delayedCallback: queryCompletions, enableDelay } = useDelayedCallback(
-    React.useCallback(
-      (text: string, completionTypes: CompletionType[]) => {
-        const phase = commandLineParser.inputPhase(text);
-        if (phase === InputPhase.OnCommand) {
-          getCommandCompletions(text).then((completions) =>
-            dispatch(actions.setCompletions(completions))
-          );
-        } else {
-          let cmd: CommandLine | null = null;
-          try {
-            cmd = commandLineParser.parse(text);
-          } catch (e) {
-            if (e instanceof UnknownCommandError) {
-              return;
-            }
+  const queryCompletions = React.useCallback(
+    (text: string, completionTypes: CompletionType[]) => {
+      const phase = commandLineParser.inputPhase(text);
+      if (phase === InputPhase.OnCommand) {
+        getCommandCompletions(text).then((completions) =>
+          dispatch(actions.setCompletions(completions))
+        );
+      } else {
+        let cmd: CommandLine | null = null;
+        try {
+          cmd = commandLineParser.parse(text);
+        } catch (e) {
+          if (e instanceof UnknownCommandError) {
+            return;
           }
-          switch (cmd?.command) {
-            case Command.Open:
-            case Command.TabOpen:
-            case Command.WindowOpen:
-              getOpenCompletions(cmd.command, cmd.args, completionTypes).then(
-                (completions) => dispatch(actions.setCompletions(completions))
-              );
-              break;
-            case Command.Buffer:
-              getTabCompletions(cmd.command, cmd.args, false).then(
-                (completions) => dispatch(actions.setCompletions(completions))
-              );
-              break;
-            case Command.BufferDelete:
-            case Command.BuffersDelete:
-              getTabCompletions(cmd.command, cmd.args, true).then(
-                (completions) => dispatch(actions.setCompletions(completions))
-              );
-              break;
-            case Command.BufferDeleteForce:
-            case Command.BuffersDeleteForce:
-              getTabCompletions(cmd.command, cmd.args, false).then(
-                (completions) => dispatch(actions.setCompletions(completions))
-              );
-              break;
-            case Command.Set:
-              getPropertyCompletions(cmd.command, cmd.args).then(
-                (completions) => dispatch(actions.setCompletions(completions))
-              );
-              break;
-          }
-          enableDelay();
         }
-      },
-      [dispatch]
-    ),
-    100
+        switch (cmd?.command) {
+          case Command.Open:
+          case Command.TabOpen:
+          case Command.WindowOpen:
+            getOpenCompletions(cmd.command, cmd.args, completionTypes).then(
+              (completions) => dispatch(actions.setCompletions(completions))
+            );
+            break;
+          case Command.Buffer:
+            getTabCompletions(cmd.command, cmd.args, false).then(
+              (completions) => dispatch(actions.setCompletions(completions))
+            );
+            break;
+          case Command.BufferDelete:
+          case Command.BuffersDelete:
+            getTabCompletions(cmd.command, cmd.args, true).then((completions) =>
+              dispatch(actions.setCompletions(completions))
+            );
+            break;
+          case Command.BufferDeleteForce:
+          case Command.BuffersDeleteForce:
+            getTabCompletions(cmd.command, cmd.args, false).then(
+              (completions) => dispatch(actions.setCompletions(completions))
+            );
+            break;
+          case Command.Set:
+            getPropertyCompletions(cmd.command, cmd.args).then((completions) =>
+              dispatch(actions.setCompletions(completions))
+            );
+            break;
+        }
+      }
+    },
+    [dispatch]
   );
 
   React.useEffect(() => {

--- a/src/console/completion/hooks/clients.ts
+++ b/src/console/completion/hooks/clients.ts
@@ -1,0 +1,23 @@
+import React from "react";
+import CompletionClient from "../../clients/CompletionClient";
+import CompletionType from "../../../shared/CompletionType";
+
+const completionClient = new CompletionClient();
+
+export const useGetCompletionTypes = (): [
+  CompletionType[] | undefined,
+  boolean
+] => {
+  type State = {
+    loading: boolean;
+    result?: CompletionType[];
+  };
+  const [state, setState] = React.useState<State>({ loading: true });
+
+  React.useEffect(() => {
+    completionClient.getCompletionTypes().then((result) => {
+      setState({ loading: false, result });
+    });
+  }, []);
+  return [state.result, state.loading];
+};

--- a/src/console/completion/reducer.ts
+++ b/src/console/completion/reducer.ts
@@ -1,7 +1,6 @@
 import Completions from "../Completions";
 import CompletionType from "../../shared/CompletionType";
 import {
-  INIT_COMPLETIONS,
   SET_COMPLETION_SOURCE,
   SET_COMPLETIONS,
   COMPLETION_NEXT,
@@ -58,13 +57,6 @@ export default function reducer(
   action: CompletionAction
 ): State {
   switch (action.type) {
-    case INIT_COMPLETIONS:
-      return {
-        ...state,
-        completionTypes: action.completionTypes,
-        completions: [],
-        select: -1,
-      };
     case SET_COMPLETION_SOURCE:
       return {
         ...state,

--- a/src/console/components/CommandPrompt.tsx
+++ b/src/console/components/CommandPrompt.tsx
@@ -22,7 +22,7 @@ const CommandPromptInner: React.FC<Props> = ({ initialInputValue }) => {
   const hide = useHide();
   const [inputValue, setInputValue] = React.useState(initialInputValue);
   const debouncedValue = useDebounce(inputValue, 100);
-  const { completions, updateCompletions } = useCompletions();
+  const { completions } = useCompletions(debouncedValue);
   const { select, currentValue, selectNext, selectPrev } =
     useSelectCompletion();
   const execCommand = useExecCommand();
@@ -82,10 +82,6 @@ const CommandPromptInner: React.FC<Props> = ({ initialInputValue }) => {
     const text = e.target.value;
     setInputValue(text);
   };
-
-  React.useEffect(() => {
-    updateCompletions(debouncedValue);
-  }, [debouncedValue]);
 
   return (
     <ConsoleWrapper>

--- a/src/console/components/CommandPrompt.tsx
+++ b/src/console/components/CommandPrompt.tsx
@@ -3,6 +3,7 @@ import Completion from "./console/Completion";
 import Input from "./console//Input";
 import styled from "styled-components";
 import { useCompletions, useSelectCompletion } from "../completion/hooks";
+import useDebounce from "../hooks/useDebounce";
 import useAutoResize from "../hooks/useAutoResize";
 import { CompletionProvider } from "../completion/provider";
 import { useExecCommand, useHide } from "../app/hooks";
@@ -20,6 +21,7 @@ interface Props {
 const CommandPromptInner: React.FC<Props> = ({ initialInputValue }) => {
   const hide = useHide();
   const [inputValue, setInputValue] = React.useState(initialInputValue);
+  const debouncedValue = useDebounce(inputValue, 100);
   const { completions, updateCompletions } = useCompletions();
   const { select, currentValue, selectNext, selectPrev } =
     useSelectCompletion();
@@ -82,8 +84,8 @@ const CommandPromptInner: React.FC<Props> = ({ initialInputValue }) => {
   };
 
   React.useEffect(() => {
-    updateCompletions(inputValue);
-  }, [inputValue]);
+    updateCompletions(debouncedValue);
+  }, [debouncedValue]);
 
   return (
     <ConsoleWrapper>

--- a/src/console/components/console/Completion.tsx
+++ b/src/console/components/console/Completion.tsx
@@ -4,8 +4,8 @@ import CompletionTitle from "./CompletionTitle";
 
 interface Item {
   icon?: string;
-  caption?: string;
-  url?: string;
+  primary?: string;
+  secondary?: string;
 }
 
 interface Group {
@@ -75,8 +75,8 @@ const Completion: React.FC<Props> = ({ select, size, completions }) => {
           shown={viewOffset <= viewIndex && viewIndex < viewOffset + size}
           key={`item-${itemIndex}`}
           icon={item.icon}
-          caption={item.caption}
-          url={item.url}
+          primary={item.primary}
+          secondary={item.secondary}
           highlight={itemIndex === select}
           aria-selected={itemIndex === select}
           role="menuitem"

--- a/src/console/components/console/CompletionItem.tsx
+++ b/src/console/components/console/CompletionItem.tsx
@@ -23,14 +23,14 @@ const Container = styled.li<{
   white-space: pre;
 `;
 
-const Caption = styled.span`
+const Primary = styled.span`
   display: inline-block;
   width: 40%;
   text-overflow: ellipsis;
   overflow: hidden;
 `;
 
-const Description = styled.span`
+const Secondary = styled.span`
   display: inline-block;
   color: ${({ theme }) => theme.completionItemDescriptionForeground};
   width: 60%;
@@ -41,19 +41,19 @@ const Description = styled.span`
 interface Props extends React.HTMLAttributes<HTMLElement> {
   shown: boolean;
   highlight: boolean;
-  caption?: string;
-  url?: string;
+  primary?: string;
+  secondary?: string;
   icon?: string;
 }
 
 const CompletionItem: React.FC<Props> = (props) => (
   <Container
     icon={props.icon || ""}
-    aria-labelledby={`completion-item-${props.caption}`}
+    aria-labelledby={`completion-item-${props.primary}`}
     {...props}
   >
-    <Caption id={`completion-item-${props.caption}`}>{props.caption}</Caption>
-    <Description>{props.url}</Description>
+    <Primary id={`completion-item-${props.primary}`}>{props.primary}</Primary>
+    <Secondary>{props.secondary}</Secondary>
   </Container>
 );
 

--- a/src/console/hooks/useDebounce.ts
+++ b/src/console/hooks/useDebounce.ts
@@ -1,0 +1,19 @@
+import React from "react";
+
+const useDebounce = <T extends unknown>(value: T, delay: number) => {
+  const [debouncedValue, setDebouncedValue] = React.useState(value);
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/src/console/index.tsx
+++ b/src/console/index.tsx
@@ -1,66 +1,20 @@
-import * as messages from "../shared/messages";
-import Console from "./components/Console";
-import "./index.css";
 import React from "react";
 import ReactDOM from "react-dom";
 import ColorSchemeProvider from "./colorscheme/providers";
 import { AppProvider } from "./app/provider";
-import {
-  useCommandMode,
-  useFindMode,
-  useInfoMessage,
-  useErrorMessage,
-  useHide,
-} from "./app/hooks";
-
-const RootComponent: React.FC = () => {
-  const hide = useHide();
-  const { show: showCommand } = useCommandMode();
-  const { show: showFind } = useFindMode();
-  const { show: showError } = useErrorMessage();
-  const { show: showInfo } = useInfoMessage();
-
-  React.useEffect(() => {
-    const onMessage = async (message: any): Promise<any> => {
-      const msg = messages.valueOf(message);
-      switch (msg.type) {
-        case messages.CONSOLE_SHOW_COMMAND:
-          showCommand(msg.command);
-          break;
-        case messages.CONSOLE_SHOW_FIND:
-          showFind();
-          break;
-        case messages.CONSOLE_SHOW_ERROR:
-          showError(msg.text);
-          break;
-        case messages.CONSOLE_SHOW_INFO:
-          showInfo(msg.text);
-          break;
-        case messages.CONSOLE_HIDE:
-          hide();
-          break;
-      }
-    };
-
-    browser.runtime.onMessage.addListener(onMessage);
-    const port = browser.runtime.connect(undefined, {
-      name: "vimvixen-console",
-    });
-    port.onMessage.addListener(onMessage);
-  }, []);
-
-  return <Console />;
-};
-
-const App: React.FC = () => (
-  <AppProvider>
-    <ColorSchemeProvider>
-      <RootComponent />
-    </ColorSchemeProvider>
-  </AppProvider>
-);
+import App from "./App";
+import "./index.css";
 
 window.addEventListener("DOMContentLoaded", () => {
   const wrapper = document.getElementById("vimvixen-console");
-  ReactDOM.render(<App />, wrapper);
+  ReactDOM.render(
+    <React.StrictMode>
+      <AppProvider>
+        <ColorSchemeProvider>
+          <App />
+        </ColorSchemeProvider>
+      </AppProvider>
+    </React.StrictMode>,
+    wrapper
+  );
 });

--- a/test/console/completion/reducer.test.ts
+++ b/test/console/completion/reducer.test.ts
@@ -3,29 +3,13 @@ import reducer, {
   State,
 } from "../../../src/console/completion/reducer";
 import {
-  initCompletion,
   selectNext,
   selectPrev,
   setCompletions,
   setCompletionSource,
 } from "../../../src/console/completion/actions";
-import CompletionType from "../../../src/shared/CompletionType";
 
 describe("completion reducer", () => {
-  describe("initCompletion", () => {
-    it("initializes completions", () => {
-      const nextState = reducer(
-        defaultState,
-        initCompletion([CompletionType.Bookmarks, CompletionType.History])
-      );
-
-      expect(nextState.completionTypes).toEqual([
-        CompletionType.Bookmarks,
-        CompletionType.History,
-      ]);
-    });
-  });
-
   describe("setCompletionSource", () => {
     it("sets a completion source", () => {
       const nextState = reducer(defaultState, setCompletionSource("open "));

--- a/test/console/components/console/Completion.test.tsx
+++ b/test/console/components/console/Completion.test.tsx
@@ -9,17 +9,17 @@ describe("console/components/console/completion/Completion", () => {
     {
       name: "Fruit",
       items: [
-        { caption: "apple" },
-        { caption: "banana" },
-        { caption: "cherry" },
+        { primary: "apple" },
+        { primary: "banana" },
+        { primary: "cherry" },
       ],
     },
     {
       name: "Element",
       items: [
-        { caption: "argon" },
-        { caption: "boron" },
-        { caption: "carbon" },
+        { primary: "argon" },
+        { primary: "boron" },
+        { primary: "carbon" },
       ],
     },
   ];
@@ -39,7 +39,7 @@ describe("console/components/console/completion/Completion", () => {
       const items = group.findAllByType(CompletionItem);
       expect(items).toHaveLength(completions[i].items.length);
       items.forEach((item, j) => {
-        expect(item.props.caption).toEqual(completions[i].items[j].caption);
+        expect(item.props.primary).toEqual(completions[i].items[j].primary);
       });
     });
   });

--- a/test/console/components/console/CompletionItem.test.tsx
+++ b/test/console/components/console/CompletionItem.test.tsx
@@ -8,8 +8,8 @@ describe("console/components/console/completion/CompletionItem", () => {
       <CompletionItem
         shown={true}
         highlight={false}
-        caption="twitter"
-        url="https://twitter.com/"
+        primary="twitter"
+        secondary="https://twitter.com/"
       />
     ).root;
     const spans = root.findAllByType("span");


### PR DESCRIPTION
By https://github.com/ueokande/vim-vixen/pull/1099, the console delays completions in asynchronous.  It can occur that is input value does not match the displayed completions.  It can occur that is input value does not match the displayed completions.  For example, the completion item `Site A` is selected, but the input field shows `Site B`.  The reproduce steps the following:
1. Press <kbd>o</kbd> to show `:open` command
2.  Type some keys
3. Pres <kbd>Tab</kbd> key immediately, before the completions are displayed.

This change awaits fetching completions when users press the <kbd>Tab</kbd> key to prevent the issue.