### PR TITLE
Fix white box on sites using dark mode

### DIFF
--- a/src/content/site-style.ts
+++ b/src/content/site-style.ts
@@ -10,6 +10,7 @@ export default `
   border: none !important;
   background-color: unset !important;
   pointer-events:none;
+  color-scheme: light;
 }
 
 .vimvixen-hint {


### PR DESCRIPTION
Sites that use `color-scheme: dark` result in Vim Vixen's iframe looking
like a white box when it's actually supposed to be hidden. This started
in Firefox 102.

![image](https://user-images.githubusercontent.com/1713819/176747451-16aca848-aaf1-488f-84e4-0000367bc4e9.png)


Fixes #1433
Fixes #1424
Fixes #1429
