### PR TITLE
Move white iframe deeper with z-index at Firefox 102+

### DIFF
--- a/src/content/site-style.ts
+++ b/src/content/site-style.ts
@@ -6,7 +6,7 @@ export default `
   left: 0;
   width: 100%;
   position: fixed;
-  z-index: 2147483647;
+  z-index: -999;
   border: none !important;
   background-color: unset !important;
   pointer-events:none;


### PR DESCRIPTION
Applied `z-index: -999;` to `.vimvixen-console-frame` for hide white system iframe at dark themed sites.
Fixed:
#1424 
#1429 
#1433 