### PR TITLE
Fix opaque console iframe overlaying some websites

### DIFF
--- a/src/console/index.tsx
+++ b/src/console/index.tsx
@@ -6,7 +6,7 @@ import App from "./App";
 import "./index.css";
 
 const colorScheme = (new URLSearchParams(window.location.search)).get('colorScheme')
-/* @ts-ignore */
+/* @ts-expect-error: The colorScheme property is not on the CSSStyleDeclaration type in TypeScript v4.3.5 */
 window.document.documentElement.style.colorScheme = colorScheme ?? ''
 
 window.addEventListener("DOMContentLoaded", () => {

--- a/src/content/presenters/ConsoleFramePresenter.ts
+++ b/src/content/presenters/ConsoleFramePresenter.ts
@@ -19,7 +19,7 @@ export class ConsoleFramePresenterImpl implements ConsoleFramePresenter {
       return;
     }
 
-    /* @ts-ignore */
+    /* @ts-expect-error: The colorScheme property is not on the CSSStyleDeclaration type in TypeScript v4.3.5 */
     const colorScheme = getComputedStyle(document.body).colorScheme
     const iframe = document.createElement("iframe");
     iframe.src = browser.runtime.getURL("build/console.html?colorScheme=" + colorScheme);


### PR DESCRIPTION
This PR fixes the following issue where the console iframe is not transparent on sites that specify a `color-scheme`, such as GitHub:

![image](https://user-images.githubusercontent.com/4977161/177530584-2b3945f3-fde1-4378-995f-053afe87f9e2.png)

The issue is caused by a change in Firefox where it will now make iframes opaque if their `color-scheme` differs from the parent page. The Vim Vixen iframe currently doesn't specify a `color-scheme`, but sites like GitHub do, hence the issue.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1738380 and https://fvsch.com/transparent-iframes

This PR makes two changes to solve this:

**1. Set the appropriate `color-scheme` on the console.**

The `ConsoleFramePresenter` gets the computed `color-scheme` for the `<body>` tag where the `<iframe>` will be injected and passes it to the console page via a query string parameter.

The console page takes the query string parameter and updates the `colorScheme` style property on the root element.

While this does fix the issue once the page has loaded, the white overlay is still briefly visible while it's loading.

I tried several methods to set the `color-scheme` but this was the only way I could set the value with the cross-origin of the `<iframe>`. I'm open to alternatives.

**2. Shrink the `<iframe>` when not in use.**

To hide the white overlay while the page is loading, I've set the initial height of the `<iframe>` to `0px`. The `useAutoResize` hook already sets the correct height on the `<iframe>` once the user triggers it.

While not strictly necessary, I've also set the `<iframe>` height back to `0px` when the console is closed. This solves a minor issue I've had during web development where the browser element selector will highlight the invisible Vim Vixen `<iframe>` at the bottom of the page which makes it hard to select items underneath it.

The shrinking of the `<iframe>` makes setting the `color-scheme` _almost_ unnecessary. However, I've left it for a few reasons:
1. When closing the console, occasionally I was able to see the white background briefly before the resize kicks in.
2. When the console is open, there is a thin white line visible above it. This could probably be solved with CSS.
3. Making the background transparent is presumably valuable for those with a semi-opaque console background theme.

Fixes #1424
Fixes #1429
Fixes #1433