### PR TITLE
Add Brave Search

### DIFF
--- a/src/shared/settings/Settings.ts
+++ b/src/shared/settings/Settings.ts
@@ -150,6 +150,7 @@ export const DefaultSettingJSONText = `{
       "yahoo": "https://search.yahoo.com/search?p={}",
       "bing": "https://www.bing.com/search?q={}",
       "duckduckgo": "https://duckduckgo.com/?q={}",
+      "brave": "https://search.brave.com/search?q={}",
       "twitter": "https://twitter.com/search?q={}",
       "wikipedia": "https://en.wikipedia.org/w/index.php?search={}"
     }


### PR DESCRIPTION
Adds Brave search to the default search engines learn more here:
https://brave.com/brave-search-beta/