### PR TITLE
Fix visible vim-vixem iframe

### DIFF
--- a/src/content/presenters/ConsoleFramePresenter.ts
+++ b/src/content/presenters/ConsoleFramePresenter.ts
@@ -42,12 +42,8 @@ export class ConsoleFramePresenterImpl implements ConsoleFramePresenter {
     ele.blur();
   }
 
-  resize(_width: number, height: number): void {
-    const ele = document.getElementById("vimvixen-console-frame");
-    if (!ele) {
-      return;
-    }
-    ele.style.height = `${height}px`;
+  resize(_width: number, _height: number): void {
+    return;
   }
 
   isTopWindow(): boolean {

--- a/src/content/site-style.ts
+++ b/src/content/site-style.ts
@@ -5,6 +5,7 @@ export default `
   bottom: 0;
   left: 0;
   width: 100%;
+  height: 0;
   position: fixed;
   z-index: 2147483647;
   border: none !important;


### PR DESCRIPTION
Hi!

This PR fixes #1424 and #1433.

I'm not sure if there is a reason for the vim-vixem iframe height to be updated on resize but nothing seems to be broken in my tests when ignoring it:
https://github.com/ueokande/vim-vixen/blob/62f4610f2b9e3d49ac4b3f09074f543939720ffb/src/content/presenters/ConsoleFramePresenter.ts#L45-L51

Let me know what you think 😁 